### PR TITLE
Fixes memory leak in image stream

### DIFF
--- a/src/main/cpp/FfmpegMediaPlayer.cpp
+++ b/src/main/cpp/FfmpegMediaPlayer.cpp
@@ -684,7 +684,7 @@ JNIEXPORT jint JNICALL Java_org_datavyu_plugins_ffmpeg_FfmpegMediaPlayer_ffmpegU
 	jbyte* pData = env->GetByteArrayElements(data, 0);
 	jlong len = env->GetArrayLength(data);
 	uint32_t uErrCode = pPipeline->UpdateImageBuffer((uint8_t*)pData, len);
-	env->ReleaseByteArrayElements(data, pData, JNI_COMMIT);
+	env->ReleaseByteArrayElements(data, pData, 0);
 	return uErrCode;
 }
 

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -807,7 +807,7 @@ void FfmpegSdlAvPlayback::init() {
 void FfmpegSdlAvPlayback::destroy() {
 
 	// only necessary when using as library -- has no effect otherwise
-	stop_display_loop(); 
+	stop_display_loop();
 
 	// close the VideoState Stream
 	if (pVideoState)
@@ -842,14 +842,9 @@ void FfmpegSdlAvPlayback::destroy() {
 #endif
 	avformat_network_deinit();
 
-	if (show_status)
-		printf("\n");
-
 	SDL_Quit();
 	
 	av_log(NULL, AV_LOG_QUIET, "%s", "");
-	
-	exit(0);
 }
 
 void FfmpegSdlAvPlayback::init_and_event_loop() {
@@ -869,12 +864,14 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 		case SDL_KEYDOWN:
 			if (exit_on_keydown) {
 				destroy();
+				exit(0); // need to exit here to avoid joinable exception
 				break;
 			}
 			switch (event.key.keysym.sym) {
 			case SDLK_ESCAPE:
 			case SDLK_q:
 				destroy();
+				exit(0); // need to exit here to avoid joinable exception
 				break;
 			case SDLK_f:
 				toggle_full_screen();
@@ -1071,6 +1068,7 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 		case SDL_QUIT:
 		case FF_QUIT_EVENT:
 			destroy();
+			exit(0);  // need to exit here to avoid joinable exception
 			break;
 		default:
 			break;

--- a/src/main/cpp/ffplay.cpp
+++ b/src/main/cpp/ffplay.cpp
@@ -3,10 +3,9 @@
 int main(int argc, char **argv) {
 	av_log_set_flags(AV_LOG_SKIP_REPEATED);
 	av_log(NULL, AV_LOG_WARNING, "Init Network\n");
-	static const char* input_filename = "counter.mp4";
+	static const char* input_filename = "Nature_30fps_1080p.mp4";
 	AVInputFormat *file_iformat = nullptr;
 	FfmpegSdlAvPlayback* pPlayer = new FfmpegSdlAvPlayback(input_filename, file_iformat);
 	pPlayer->init_and_event_loop();
-	pPlayer->destroy();
 	return 0;
 }

--- a/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleMediaPlayerExample.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleMediaPlayerExample.java
@@ -24,11 +24,8 @@ public class SimpleMediaPlayerExample {
         // Create the media player using the constructor with File
         MediaPlayerData mediaPlayer = new FfmpegMediaPlayer(new File(movieFileName), new JFrame());
 
-        // Open a Jframe for data streaming through Java
-//        MediaPlayer mediaPlayer = new FfmpegMediaPlayer(URI.create(movieFileName), new JFrame());
-
         // Stream through SDL
-        //MediaPlayer mediaPlayer = new FfmpegMediaPlayer(URI.create(movieFileName));
+        //MediaPlayer mediaPlayer = new FfmpegMediaPlayer(new File(movieFileName));
 
         mediaPlayer.addMediaErrorListener(new MediaErrorListener() {
             @Override
@@ -46,6 +43,7 @@ public class SimpleMediaPlayerExample {
 
         // Open a Jframe for debugging purposes
         JFrame frame = new JFrame();
+
         frame.addKeyListener(new KeyListener() {
             @Override
             public void keyTyped(KeyEvent e) {
@@ -127,6 +125,7 @@ public class SimpleMediaPlayerExample {
             @Override
             public void keyReleased(KeyEvent e) { }
         });
+
         frame.setSize(640, 480);
         frame.setVisible(true);
     }


### PR DESCRIPTION
- Do not use JNI_COMMIT (instead use 0) in the release function

I've also deployed that as artifact
0.18-20180813.001945-34

and tested this in datavyu.

There the memory consumption stays now constant <250 MB when playing back the video 'DatavyuSampleVideo.mp4'