### PR TITLE
Proper error handling when allocating memory

### DIFF
--- a/src/main/cpp/FfmpegAvPlayback.cpp
+++ b/src/main/cpp/FfmpegAvPlayback.cpp
@@ -1,5 +1,5 @@
 #include "FfmpegAvPlayback.h"
-
+#include "FfmpegMediaErrors.h"
 
 void FfmpegAvPlayback::stream_toggle_pause() {
 	
@@ -27,13 +27,23 @@ void FfmpegAvPlayback::stream_toggle_pause() {
 	pExtclk->setPaused(flipped);
 }
 
-FfmpegAvPlayback::FfmpegAvPlayback(const char *filename, AVInputFormat *iformat) :
-	pVideoState(VideoState::stream_open(filename, iformat)),
+FfmpegAvPlayback::FfmpegAvPlayback() :
+	pVideoState(nullptr),
 	display_disable(0),
 	width(0),
 	height(0),
 	force_refresh(1)
 { }
+
+int FfmpegAvPlayback::Init(const char *filename, AVInputFormat *iformat) {
+	pVideoState = VideoState::stream_open(filename, iformat);
+
+	if (!pVideoState) {
+		return ERROR_PLAYER_NULL;
+	}
+
+	return ERROR_NONE;
+}
 
 FfmpegAvPlayback::~FfmpegAvPlayback() {}
 
@@ -107,8 +117,8 @@ int FfmpegAvPlayback::get_frame_timer() {
 	return frame_timer;
 }
 
-void FfmpegAvPlayback::set_frame_timer(int newFrame_timer) {
-	frame_timer = newFrame_timer;
+void FfmpegAvPlayback::set_frame_timer(int new_frame_timer) {
+	frame_timer = new_frame_timer;
 }
 
 void FfmpegAvPlayback::set_force_refresh(int refresh) {

--- a/src/main/cpp/FfmpegAvPlayback.h
+++ b/src/main/cpp/FfmpegAvPlayback.h
@@ -5,7 +5,7 @@
 
 class FfmpegAvPlayback {
 protected:
-	VideoState * pVideoState;
+	VideoState* pVideoState;
 	double frame_timer;
 
 	int width, height;
@@ -21,8 +21,8 @@ protected:
 	void set_force_refresh(int refresh);
 	double vp_duration(Frame *vp, Frame *nextvp, double max_frame_duration);
 public:
-
-	FfmpegAvPlayback(const char *filename, AVInputFormat *iformat);
+	FfmpegAvPlayback();
+	int Init(const char *filename, AVInputFormat *iformat);
 	virtual ~FfmpegAvPlayback();
 	virtual void set_player_state_callback_func(PlayerStateCallback callback, const std::function<void()>& func);
 	virtual void play();

--- a/src/main/cpp/FfmpegJavaAvPlayback.h
+++ b/src/main/cpp/FfmpegJavaAvPlayback.h
@@ -10,14 +10,14 @@ private:
 	const PixelFormat* pPixelFormat;
 	const int audioBufferSizeInBy;
 	struct SwsContext* img_convert_ctx;
-	void init();
 public:
-	FfmpegJavaAvPlayback(const char *filename, 
-		AVInputFormat *iformat, 
-		const AudioFormat *pAudioFormat, 
+	FfmpegJavaAvPlayback(const AudioFormat *pAudioFormat,
 		const PixelFormat *pPixelFormat,
 		const int audioBufferSizeInBy);
-	~FfmpegJavaAvPlayback();
+	virtual ~FfmpegJavaAvPlayback();
+
+	int Init(const char *filename,
+		AVInputFormat *iformat);
 
 	int audio_open(int64_t wanted_channel_layout, int wanted_nb_channels,
 		int wanted_sample_rate, struct AudioParams *audio_hw_params);
@@ -26,7 +26,7 @@ public:
 
 	void destroy();
 
-	void init_and_start_stream();
+	void start_stream();
 
 	void set_balance(float fBalance);
 	float get_balance();

--- a/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
@@ -1,12 +1,25 @@
 #include "FfmpegJavaAvPlaybackPipline.h"
 
 uint32_t FfmpegJavaAvPlaybackPipline::Init(const char * input_file) {
+
 	av_log_set_flags(AV_LOG_SKIP_REPEATED);
 	av_log(NULL, AV_LOG_WARNING, "Init Network\n");
 	AVInputFormat *file_iformat = nullptr;
-	pJavaPlayback = new FfmpegJavaAvPlayback(input_file, 
-		file_iformat, m_pOptions->GetAudioFormat(), m_pOptions->GetPixelFormat(), 
+	pJavaPlayback = new (std::nothrow) FfmpegJavaAvPlayback(
+		m_pOptions->GetAudioFormat(), 
+		m_pOptions->GetPixelFormat(), 
 		m_pOptions->GetAudioBufferSizeInBy());
+
+	if (!pJavaPlayback) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to initialize the java playback pipeline");
+		return ERROR_PIPELINE_NULL;
+	}
+
+	int err = pJavaPlayback->Init(input_file, file_iformat);
+	if (err) {
+		delete pJavaPlayback;
+		return err;
+	}
 
 	// Assign the callback functions
 	pJavaPlayback->set_player_state_callback_func(TO_UNKNOWN, [this] {
@@ -31,7 +44,7 @@ uint32_t FfmpegJavaAvPlaybackPipline::Init(const char * input_file) {
 		this->UpdatePlayerState(Finished);
 	});
 
-	pJavaPlayback->init_and_start_stream();
+	pJavaPlayback->start_stream();
 
 	return ERROR_NONE;
 }

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -1,4 +1,5 @@
 #include "FfmpegSdlAvPlayback.h"
+#include "FfmpegMediaErrors.h"
 
 /* Private Members */
 inline int FfmpegSdlAvPlayback::compute_mod(int a, int b) {
@@ -45,18 +46,35 @@ void FfmpegSdlAvPlayback::calculate_display_rect(SDL_Rect *rect,
 	rect->h = FFMAX(height, 1);
 }
 
-FfmpegSdlAvPlayback::FfmpegSdlAvPlayback(
-	const char *filename,
-	AVInputFormat *iformat) : 
-	FfmpegAvPlayback(filename, iformat),
+FfmpegSdlAvPlayback::FfmpegSdlAvPlayback() : 
+	FfmpegAvPlayback(),
 	ytop(0),
 	xleft(0),
 	rdftspeed(0.02),
 	window(nullptr),
-	renderer(nullptr)
-{
+	renderer(nullptr),
+	img_convert_ctx(nullptr),
+	sub_convert_ctx(nullptr),
+	vis_texture(nullptr),
+	sub_texture(nullptr),
+	vid_texture(nullptr) {}
+
+FfmpegSdlAvPlayback::~FfmpegSdlAvPlayback() {}
+
+int FfmpegSdlAvPlayback::Init(const char *filename, AVInputFormat *iformat) {
+	/* register all codecs, demux and protocols */
+#if CONFIG_AVDEVICE
+	avdevice_register_all();
+#endif
+	avformat_network_init();
+
+	int err = FfmpegAvPlayback::Init(filename, iformat);
+	if (err) {
+		return err;
+	}
+
 	// Set callback functions
-	pVideoState->set_audio_open_callback([this](int64_t wanted_channel_layout, int wanted_nb_channels, 
+	pVideoState->set_audio_open_callback([this](int64_t wanted_channel_layout, int wanted_nb_channels,
 		int wanted_sample_rate, struct AudioParams *audio_hw_params) {
 		return this->audio_open(wanted_channel_layout, wanted_nb_channels, wanted_sample_rate,
 			audio_hw_params);
@@ -70,9 +88,9 @@ FfmpegSdlAvPlayback::FfmpegSdlAvPlayback(
 	pVideoState->set_step_to_next_frame_callback([this] {
 		this->step_to_next_frame();
 	});
-}
 
-FfmpegSdlAvPlayback::~FfmpegSdlAvPlayback() {};
+	return ERROR_NONE;
+}
 
 /* Public Members */
 int FfmpegSdlAvPlayback::audio_open(int64_t wanted_channel_layout, int wanted_nb_channels, int wanted_sample_rate,
@@ -749,12 +767,7 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
 	}
 }
 
-void FfmpegSdlAvPlayback::init() {
-	/* register all codecs, demux and protocols */
-#if CONFIG_AVDEVICE
-	avdevice_register_all();
-#endif
-	avformat_network_init();
+void FfmpegSdlAvPlayback::InitSdl() {
 
 	if (display_disable) {
 		pVideoState->set_video_disable(1);
@@ -855,7 +868,7 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 	SDL_Event event;
 	double incr, pos, frac;
 	// Initialize first before starting the stream
-	init();
+	InitSdl();
 	pVideoState->stream_start();
 	for (;;) {
 		double x;
@@ -1078,15 +1091,15 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 
 
 
-void FfmpegSdlAvPlayback::init_and_start_display_loop() {
+int FfmpegSdlAvPlayback::init_and_start_display_loop() {
 	std::mutex mtx;
 	std::condition_variable cv;
 	bool initialized = false;
 
 	// TODO(fraudies): Check for the case when the thread can't be initialized and return appropriate error (change method signature)
-	display_tid = new std::thread([this, &initialized, &cv] {
+	display_tid = new (std::nothrow) std::thread([this, &initialized, &cv] {
 
-		init();
+		InitSdl();
 		initialized = true;
 		cv.notify_all();
 
@@ -1114,9 +1127,16 @@ void FfmpegSdlAvPlayback::init_and_start_display_loop() {
 		}
 	});
 
+	if (!display_tid) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create playback thread");
+		return -1;
+	}
+
 	std::unique_lock<std::mutex> lck(mtx);
 	cv.wait(lck, [&initialized] {return initialized; });
 	pVideoState->stream_start();
+
+	return 0;
 }
 
 void FfmpegSdlAvPlayback::stop_display_loop() {

--- a/src/main/cpp/FfmpegSdlAvPlayback.h
+++ b/src/main/cpp/FfmpegSdlAvPlayback.h
@@ -100,15 +100,17 @@ private:
 	std::atomic<bool> stopped = false;
 	std::thread* display_tid = nullptr;
 
-	void init(); // This is private because it has to be called on the same thread as the looping
+	void InitSdl(); // This is private because it has to be called on the same thread as the looping
 	int video_open(const char* filename);
 	void closeAudioDevice();
 	void video_image_display();
 	void stop_display_loop();
 	void toggle_audio_display();
 public:
-	FfmpegSdlAvPlayback(const char *filename, AVInputFormat *iformat);
+	FfmpegSdlAvPlayback();
 	~FfmpegSdlAvPlayback();
+
+	int Init(const char *filename, AVInputFormat *iformat);
 
 	VideoState* get_VideoState();
 
@@ -152,6 +154,6 @@ public:
 
 	void init_and_event_loop();
 
-	void init_and_start_display_loop();
+	int init_and_start_display_loop();
 };
 #endif FFMPEGSDLAVPLAYBACK_H_

--- a/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
@@ -14,7 +14,17 @@ uint32_t FfmpegSdlAvPlaybackPipeline::Init(const char * input_file) {
 	av_log_set_flags(AV_LOG_SKIP_REPEATED);
 	av_log(NULL, AV_LOG_WARNING, "Init Network\n");
 	AVInputFormat *file_iformat = nullptr;
-	pSdlPlayback = new FfmpegSdlAvPlayback(input_file, file_iformat);
+	pSdlPlayback = new (std::nothrow) FfmpegSdlAvPlayback();
+
+	if (!pSdlPlayback) {
+		return ERROR_PIPELINE_NULL;
+	}
+
+	int err = pSdlPlayback->Init(input_file, file_iformat);
+	if (err) {
+		delete pSdlPlayback;
+		return err;
+	}
 
 	// Assign the callback functions	
 	pSdlPlayback->set_player_state_callback_func(TO_UNKNOWN, [this] {

--- a/src/main/cpp/FrameQueue.h
+++ b/src/main/cpp/FrameQueue.h
@@ -59,44 +59,48 @@ class FrameQueue{
 		static void unref_item(Frame *vp) {
 			av_frame_unref(vp->frame);
 		}
-    public:
-		FrameQueue(const PacketQueue* pktq, int max_size, int keep_last);
 
-		// Same like PacketQueue we should destroy the mutex 
-        virtual ~FrameQueue() {
-            for (int i = 0; i < max_size; i++) {
-                Frame *vp = &queue[i];
-                unref_item(vp);
-                av_frame_free(&vp->frame);
-            }
-			delete[] queue;
+		FrameQueue(const PacketQueue* pktq, int max_size, int keep_last); // private because of memory management
+public:
+	// Use this method to create a new frame queue to ensure cases where memory allocation fails are handled properly
+	static FrameQueue* create_frame_queue(const PacketQueue* pktq, int max_size, int keep_last);
+
+    virtual ~FrameQueue() {
+        for (int i = 0; i < max_size; i++) {
+            Frame *vp = &queue[i];
+			if (vp) {
+				unref_item(vp);
+				av_frame_free(&vp->frame);
+			}
         }
+		delete[] queue;
+    }
 
-		void signal();
+	void signal();
 
-        inline Frame* peek() { return &queue[(rindex + rindex_shown) % max_size]; }
+    inline Frame* peek() { return &queue[(rindex + rindex_shown) % max_size]; }
 
-        inline Frame* peek_next() { return &queue[(rindex + rindex_shown + 1) % max_size]; }
+    inline Frame* peek_next() { return &queue[(rindex + rindex_shown + 1) % max_size]; }
 
-        inline Frame* peek_last() { return &queue[rindex]; }
+    inline Frame* peek_last() { return &queue[rindex]; }
 
-		inline std::mutex & get_mutex() { return mutex; }
+	inline std::mutex & get_mutex() { return mutex; }
 
-		inline int get_rindex_shown() const { return rindex_shown; }
+	inline int get_rindex_shown() const { return rindex_shown; }
 
-		Frame *peek_writable();
+	Frame *peek_writable();
 
-		Frame *peek_readable();
+	Frame *peek_readable();
 
-		void push();
+	void push();
 
-		void next();
+	void next();
 
-        // return the number of undisplayed frames in the queue
-        inline int nb_remaining() const { return size - rindex_shown; }
+    // return the number of undisplayed frames in the queue
+    inline int nb_remaining() const { return size - rindex_shown; }
 
-        // return last shown position
-		int64_t last_pos();
+    // return last shown position
+	int64_t last_pos();
 };
 
 #endif FRAME_QUEUE_H_

--- a/src/main/cpp/TestFrameQueue.cpp
+++ b/src/main/cpp/TestFrameQueue.cpp
@@ -16,7 +16,7 @@
 
 TEST_CASE( "Create and delete (pass)", "[create-delete]" ) {
 	PacketQueue packetQueue;
-    FrameQueue frameQueue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+    FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
 }
 
 TEST_CASE( "Test single write and read (pass)", "[single-read-write]" ) {
@@ -26,7 +26,7 @@ TEST_CASE( "Test single write and read (pass)", "[single-read-write]" ) {
 	packetQueue.start();
 
 	// Initialize the frame queue
-	FrameQueue frameQueue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+	FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
 
 	// Write
 	Frame* pWriteable = frameQueue.peek_writable();
@@ -48,7 +48,7 @@ TEST_CASE("Test status (pass)", "[status]") {
 	packetQueue.start();
 
 	// Initialize the frame queue
-	FrameQueue frameQueue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+	FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
 
 	// Test the intial status of the frame queue
 	REQUIRE(frameQueue.nb_remaining() == 0);
@@ -75,7 +75,7 @@ TEST_CASE("Test multi-threaded write and read (pass)", "[multi-threaded-read-wri
 	packetQueue.start();
 
 	// Initialize the frame queue with smaller size to test for blocking/unblocking
-	FrameQueue frameQueue(&packetQueue, VIDEO_PICTURE_QUEUE_SIZE, 1);
+	FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, VIDEO_PICTURE_QUEUE_SIZE, 1);
 
 	// Write some frames
 	std::thread writer([&frameQueue] {
@@ -108,7 +108,7 @@ TEST_CASE("Test signal", "[signal]") {
 	packetQueue.start();
 
 	// Initialize the frame queue
-	FrameQueue frameQueue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+	FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
 
 	// Read packet but blocked
 	std::thread reader([&frameQueue] {
@@ -127,7 +127,7 @@ TEST_CASE("Test peek, peek next, and peek last", "[peek-next-last]") {
 	packetQueue.start();
 
 	// Initialize the frame queue
-	FrameQueue frameQueue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+	FrameQueue frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
 
 	// Write frames with pos 1, 2, 3, 4
 	for (int writes = 1; writes <= 4; ++writes) {

--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -559,49 +559,184 @@ int VideoState::audio_decode_frame() {
 	return resampled_data_size;
 }
 
-/* Constructor */
-VideoState::VideoState() :
-	pVideoq(new PacketQueue()),
-	pAudioq(new PacketQueue()),
-	pSubtitleq(new PacketQueue()),
-	pPictq(nullptr),
-	pSubpq(nullptr),
-	pSampq(nullptr),
-	pVidclk(nullptr),
-	pAudclk(nullptr),
-	pExtclk(new Clock()), // For the external clock the serial is set to itself (never triggers)
-	pViddec(nullptr), // Decoder's are created in the stream_component_open and destroyed in stream_component_close
-	pSubdec(nullptr),
-	pAuddec(nullptr),
+// Note, queues and clocks get initialized in the create_video_state function
+// The initialization order is correct now, but it is not garuanteed that some
+// of these might be null; hence, we initialize this in the create function
+VideoState::VideoState() : 
+	abort_request(0),
+	paused(true), // TRUE
+	last_paused(0),
+	stopped(false),
+	queue_attachments_req(0),
+	seek_req(0),
+	seek_flags(0),
+	seek_pos(0),
+	seek_rel(0),
+	read_pause_return(0),
+	realtime(0),
+	av_sync_type(0),
+	fps(0),
+	subtitle_stream(0),
+	frame_last_returned_time(0),
+	frame_last_filter_delay(0),
+	video_stream(0),
+	max_frame_duration(0),
+	eof(0),
+	image_width(0),
+	image_height(0),
+	step(false),
 	newSpeed_req(0),
-	last_speed(1.0),
-	pts_speed(1.0),
+	last_speed(1.0), // 1.0
+	pts_speed(1.0), // 1.0
 	audio_disable(0),
 	video_disable(0),
 	subtitle_disable(0),
-	paused(true), // Disable audo play when streamig through Java, Note: need to change to false when using SDL
-	stopped(false) {
-	// Frame queues depend on the packet queues that have not been initialized in initializer
-	pPictq = new FrameQueue(pVideoq, VIDEO_PICTURE_QUEUE_SIZE, 1);
-	pSubpq = new FrameQueue(pSubtitleq, SUBPICTURE_QUEUE_SIZE, 0);
-	pSampq = new FrameQueue(pAudioq, SAMPLE_QUEUE_SIZE, 1);
-	// Clocks depend on packet queues that have not been initialized in initializer
-	pVidclk = new Clock(pVideoq->get_p_serial());
-	pAudclk = new Clock(pAudioq->get_p_serial());
-	// TODO(fraudies): Define these attributes in the right order in the class, then move all back to the initializers
+	last_video_stream(0),
+	last_audio_stream(0),
+	last_subtitle_stream(0),
+	filename(nullptr),
+	pAudioq(nullptr),
+	pVideoq(nullptr),
+	pSubtitleq(nullptr),
+	pSampq(nullptr),
+	pPictq(nullptr),
+	pSubpq(nullptr),
+	pAudclk(nullptr),
+	pVidclk(nullptr),
+	pExtclk(nullptr),
+	pAuddec(nullptr),
+	pViddec(nullptr),
+	pSubdec(nullptr),
+	read_tid(nullptr),
+	iformat(nullptr),
+	ic(nullptr),
+	swr_ctx(nullptr),
+	audio_st(nullptr),
+	subtitle_st(nullptr),
+	video_st(nullptr),
+	audio_stream(0),
+	audio_clock(0.0),
+	audio_clock_serial(0),
+	audio_diff_cum(0.0),
+	audio_diff_avg_coef(0.0),
+	audio_diff_threshold(0.0),
+	audio_diff_avg_count(0),
+	audio_hw_buf_size(0),
+	audio_buf(nullptr),
+	audio_buf1(nullptr),
+	audio_buf_size(0), /* in bytes */
+	audio_buf1_size(0),
+	audio_buf_index(0), /* in bytes */
+	audio_write_buf_size(0),
+	audio_volume(0),
+	muted(0),
+	frame_drops_early(0),
+	rdft(nullptr),
+	rdft_bits(0),
+	rdft_data(nullptr)
+#if CONFIG_AVFILTER
+	,
+	vfilter_idx(0),
+	vfilters_list(nullptr),
+	vfilters(nullptr), // video filter
+	nb_vfilters(0),
+	afilters(nullptr), // audio filter Note: audio filter is not working
+	in_video_filter(nullptr),   // the first filter in the video chain
+	out_video_filter(nullptr),  // the last filter in the video chain
+	in_audio_filter(nullptr),   // the first filter in the audio chain
+	out_audio_filter(nullptr),  // the last filter in the audio chain
+	agraph(nullptr),            // audio filter graph
+	sws_dict(nullptr),			// From cmdutils
+	swr_opts(nullptr),			// From cmdutils
+#endif
+{}
+
+VideoState* VideoState::crate_video_state() {
+	// Create the video state
+	VideoState* vs = new (std::nothrow) VideoState();
+	if (!vs) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create new video state");
+		return nullptr;
+	}
+
+	// Initialize packet queues
+	vs->pAudioq = new (std::nothrow) PacketQueue();
+	if (!vs->pAudioq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create packet queue for audio");
+		delete vs;
+		return nullptr;
+	}
+	vs->pVideoq = new (std::nothrow) PacketQueue();
+	if (!vs->pVideoq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create packet queue for video");
+		delete vs;
+		return nullptr;
+	}
+	vs->pSubtitleq = new (std::nothrow) PacketQueue();
+	if (!vs->pSubtitleq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create packet queue for subtitles");
+		delete vs;
+		return nullptr;
+	}
+
+	// Handle frame queues
+	vs->pSampq = FrameQueue::create_frame_queue(vs->pAudioq, SAMPLE_QUEUE_SIZE, 1);
+	if (!vs->pSampq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for audio");
+		delete vs;
+		return nullptr;
+	}
+	vs->pPictq = FrameQueue::create_frame_queue(vs->pVideoq, VIDEO_PICTURE_QUEUE_SIZE, 1);
+	if (!vs->pPictq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for video");
+		delete vs;
+		return nullptr;
+	}
+	vs->pSubpq = FrameQueue::create_frame_queue(vs->pSubtitleq, SUBPICTURE_QUEUE_SIZE, 0);
+	if (!vs->pSubpq) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for subtitle");
+		delete vs;
+		return nullptr;
+	}
+
+	// Create clocks
+	vs->pAudclk = new (std::nothrow) Clock(vs->pAudioq->get_p_serial());
+	if (!vs->pAudclk) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create clock for audio");
+		delete vs;
+		return nullptr;
+	}
+	vs->pVidclk = new (std::nothrow) Clock(vs->pVideoq->get_p_serial());
+	if (!vs->pVidclk) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create clock for video");
+		delete vs;
+		return nullptr;
+	}
+	vs->pExtclk = new (std::nothrow) Clock();
+	if (!vs->pExtclk) {
+		av_log(NULL, AV_LOG_ERROR, "Unable to create clock for external");
+		delete vs;
+		return nullptr;
+	}
+
+	return vs;
 }
+
 
 /* Destructor */
 VideoState::~VideoState() {
-	delete(pVideoq);
-	delete(pAudioq);
-	delete(pSubtitleq);
-	delete(pPictq);
-	delete(pSubpq);
-	delete(pSampq);
-	delete(pVidclk);
-	delete(pAudclk);
-	delete(pExtclk);
+	if (pVideoq) delete(pVideoq);
+	if (pAudioq) delete(pAudioq);
+	if (pSubtitleq) delete(pSubtitleq);
+
+	if (pPictq) delete(pPictq);
+	if (pSubpq) delete(pSubpq);
+	if (pSampq) delete(pSampq);
+	
+	if (pVidclk) delete(pVidclk);
+	if (pAudclk) delete(pAudclk);
+	if (pExtclk) delete(pExtclk);
+
 #if CONFIG_AVFILTER
 	av_dict_free(&swr_opts);
 	av_dict_free(&sws_dict);
@@ -1115,7 +1250,7 @@ int VideoState::subtitle_thread() {
 
 /* Public Members*/
 VideoState *VideoState::stream_open(const char *filename, AVInputFormat *iformat) {
-	VideoState *is = new VideoState();
+	VideoState *is = VideoState::crate_video_state();
 	if (!is)
 		return NULL;
 

--- a/src/main/cpp/ffplay.cpp
+++ b/src/main/cpp/ffplay.cpp
@@ -3,9 +3,14 @@
 int main(int argc, char **argv) {
 	av_log_set_flags(AV_LOG_SKIP_REPEATED);
 	av_log(NULL, AV_LOG_WARNING, "Init Network\n");
-	static const char* input_filename = "DatavyuSampleVideo.mp4"; //"Nature_30fps_1080p.mp4";
+	static const char* input_filename = "DatavyuSampleVideo1.mp4"; //"Nature_30fps_1080p.mp4";
 	AVInputFormat *file_iformat = nullptr;
-	FfmpegSdlAvPlayback* pPlayer = new FfmpegSdlAvPlayback(input_filename, file_iformat);
+	FfmpegSdlAvPlayback* pPlayer = new FfmpegSdlAvPlayback();
+	int err = pPlayer->Init(input_filename, file_iformat);
+	if (err) {
+		fprintf(stderr, "Error %d when opening input file %s", err, input_filename);
+		return err;
+	}
 	pPlayer->init_and_event_loop();
 	return 0;
 }


### PR DESCRIPTION
- Add nothrow to new
- Log and return errors
- Add missing initializations to playback constructors
- Split init and constructor for playback pipeline constructors
- Added test as well