### PR TITLE
 Proper error handling when allocating memory

### DIFF
--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -1840,10 +1840,13 @@ double VideoState::get_fps() const {
 
 void VideoState::stream_close() {
 	/* XXX: use a special url_shutdown call to abort parse cleanly */
-	this->abort_request = 1;
-	read_tid->join();
-	delete read_tid;
-	read_tid = nullptr;
+
+	abort_request = 1;
+	if (read_tid) {
+		read_tid->join();
+		delete read_tid;
+		read_tid = nullptr;
+	}
 
 	/* close each stream */
 	if (this->audio_stream >= 0)

--- a/src/main/cpp/ffplay.cpp
+++ b/src/main/cpp/ffplay.cpp
@@ -3,7 +3,7 @@
 int main(int argc, char **argv) {
 	av_log_set_flags(AV_LOG_SKIP_REPEATED);
 	av_log(NULL, AV_LOG_WARNING, "Init Network\n");
-	static const char* input_filename = "DatavyuSampleVideo1.mp4"; //"Nature_30fps_1080p.mp4";
+	static const char* input_filename = "DatavyuSampleVideo.mp4"; //"Nature_30fps_1080p.mp4";
 	AVInputFormat *file_iformat = nullptr;
 	FfmpegSdlAvPlayback* pPlayer = new FfmpegSdlAvPlayback();
 	int err = pPlayer->Init(input_filename, file_iformat);

--- a/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleMediaPlayerExample.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleMediaPlayerExample.java
@@ -23,7 +23,7 @@ public class SimpleMediaPlayerExample {
         //String movieFileName = "C:\\Users\\DatavyuTests\\Documents\\Databrary\\datavyu-ffmpegplugin\\Nature_30fps_1080p.mp4";
 
         // Create the media player using the constructor with File
-        MediaPlayerData mediaPlayer = new FfmpegMediaPlayer(new File(movieFileName), new JFrame());
+        MediaPlayerData mediaPlayer = new FfmpegMediaPlayer(new File(movieFileName));
 
         // Stream through SDL
         //MediaPlayer mediaPlayer = new FfmpegMediaPlayer(new File(movieFileName));


### PR DESCRIPTION
- Add nothrow to new
- Log and return errors
 - Add missing initializations to playback constructors
 - Split init and constructor for playback pipeline constructors
 - Added test as well
-  Minor fix to clean-up of thread