### PR TITLE
Task dvd 524

### DIFF
--- a/src/main/cpp/Clock.h
+++ b/src/main/cpp/Clock.h
@@ -7,7 +7,7 @@ extern "C" {
 #ifndef CLOCK_H_
 #define CLOCK_H_
 
-#define AV_NOSYNC_THRESHOLD 10.0
+#define AV_NOSYNC_THRESHOLD 0.5 // 1/2 sec
 #define MICRO 1000000.0
 
 // Clock to keep decoding in sync

--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -180,7 +180,7 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
 			force_refresh = 1;
 
 			//if (pVideoState->get_step() && !pVideoState->get_paused())
-		//		stream_toggle_pause();
+			//	stream_toggle_pause();
 		}
 	display:
 		/* display picture */
@@ -192,7 +192,6 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
 			force_refresh = 0;
 			if (pVideoState->get_step() && !pVideoState->get_paused())
 				stream_toggle_pause();
-
 		}
 	}
 

--- a/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
@@ -114,8 +114,10 @@ uint32_t FfmpegJavaAvPlaybackPipline::Seek(double dSeekTime) {
 
 	double incr = dSeekTime - pos;
 
-	if (pJavaPlayback->get_start_time() != AV_NOPTS_VALUE && dSeekTime < pJavaPlayback->get_start_time() / (double)AV_TIME_BASE)
+	if (pJavaPlayback->get_start_time() != AV_NOPTS_VALUE
+		&& dSeekTime < pJavaPlayback->get_start_time() / (double)AV_TIME_BASE) {
 		dSeekTime = pJavaPlayback->get_start_time() / (double)AV_TIME_BASE;
+	}
 
 	pJavaPlayback->stream_seek((int64_t)(dSeekTime * AV_TIME_BASE), (int64_t)(incr * AV_TIME_BASE), 0);
 

--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -835,7 +835,7 @@ int VideoState::read_thread() {
 			// When toggeling the pause the external clock is set but that did not work here
 			new_rate_req = 0;
 			queue_attachments_req = 1;
-			eof = 0;
+			//eof = 0;
 		}
 
 		if (this->seek_req) {
@@ -867,10 +867,10 @@ int VideoState::read_thread() {
 					pVideoq->put_flush_packet();
 				}
 				if (this->seek_flags & AVSEEK_FLAG_BYTE) {
-					pExtclk->set_clock(NAN, 0); // TODO(fraudies): May have to put -1 here
+					pExtclk->set_clock(NAN, 0); // 0 != -1 which will return NAN for interim time 
 				}
 				else {
-					pExtclk->set_clock(seek_target / (double)AV_TIME_BASE, 0);  // TODO(fraudies): May have to put -1 here
+					pExtclk->set_clock(seek_target / (double)AV_TIME_BASE, 0); // 0 != -1 which will return NAN for interim time 
 				}
 			}
 			this->seek_req = 0;
@@ -1500,13 +1500,9 @@ double VideoState::get_duration() const {
 }
 
 double VideoState::get_stream_time() const {
-	// TODO: Maybe other places need to handle NAN; instead of picking the external clock
-	// Could also use the last time -- NAN happens after a seek
-	double time = get_master_clock();
-	if (isnan(time)) {
-		time = pExtclk->get_clock();
-	}
-	return time;
+
+	// In cases of seek the video clock/audio clock is NAN, use the external clock
+	return pExtclk->get_clock();
 }
 
 void VideoState::toggle_mute() {

--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -1500,7 +1500,6 @@ double VideoState::get_duration() const {
 }
 
 double VideoState::get_stream_time() const {
-
 	// In cases of seek the video clock/audio clock is NAN, use the external clock
 	return pExtclk->get_clock();
 }

--- a/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegJavaMediaPlayer.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegJavaMediaPlayer.java
@@ -1,12 +1,9 @@
 package org.datavyu.plugins.ffmpeg;
 
-import javafx.stage.Stage;
-import org.datavyu.plugins.ffmpeg.experimental.ImageJfxPlayerThread;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.LineUnavailableException;
-import javax.swing.*;
 import java.awt.*;
 import java.awt.color.ColorSpace;
 import java.net.URI;
@@ -124,12 +121,10 @@ public final class FfmpegJavaMediaPlayer extends FfmpegMediaPlayer implements Me
         if (0 != rc) {
             throwMediaErrorException(rc, null);
         }
-        imageCanvasPlayerThread.playImage();
     }
 
     @Override
     protected void playerStop() throws MediaException {
-        imageCanvasPlayerThread.stopImage();
         int rc = ffmpegStop(getNativeMediaRef());
         if (0 != rc) {
             throwMediaErrorException(rc, null);
@@ -138,7 +133,6 @@ public final class FfmpegJavaMediaPlayer extends FfmpegMediaPlayer implements Me
 
     @Override
     protected void playerPause() throws MediaException {
-        imageCanvasPlayerThread.stopImage();
         int rc = ffmpegPause(getNativeMediaRef());
         if (0 != rc) {
             throwMediaErrorException(rc, null);
@@ -148,7 +142,6 @@ public final class FfmpegJavaMediaPlayer extends FfmpegMediaPlayer implements Me
     @Override
     protected void playerStepForward() throws MediaException {
         int rc = ffmpegStepForward(getNativeMediaRef());
-        imageCanvasPlayerThread.stepImage();
         if (0 != rc) {
             throwMediaErrorException(rc, null);
         }
@@ -261,7 +254,6 @@ public final class FfmpegJavaMediaPlayer extends FfmpegMediaPlayer implements Me
     @Override
     protected void playerSeek(double streamTime) throws MediaException {
         int rc = ffmpegSeek(getNativeMediaRef(), streamTime);
-        imageCanvasPlayerThread.stepImage();
         if (0 != rc) {
             throwMediaErrorException(rc, null);
         }

--- a/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
@@ -24,7 +24,6 @@ public class ImageCanvasPlayerThread extends Thread {
     private static final int NUM_COLOR_CHANNELS = 3;
     private static final int NUM_BUFFERS = 3;
     private volatile boolean terminate = false;
-    private volatile boolean play = false;
     private int width;
     private int height;
     private static final double REFRESH_PERIOD = 0.01; // >= 1/fps
@@ -93,40 +92,18 @@ public class ImageCanvasPlayerThread extends Thread {
         launcher(() -> updateDisplay());
     }
 
-    public void playImage() {
-        play = true;
-    }
-
-    public void stopImage() {
-        play = false;
-    }
-
-    public void stepImage() {
-        // If we are not playing, which we should, then load and display one image
-        if (!play) {
-            loadAndDisplayImage();
-        }
-    }
-
-    private void loadAndDisplayImage() {
-        mediaPlayerData.updateImageData(data);
-        //LOGGER.info("Presentation time is: " + mediaPlayerData.getPresentationTime() + " sec");
-        // Create data buffer
-        DataBufferByte dataBuffer = new DataBufferByte(data, width*height);
-        // Create writable raster
-        WritableRaster raster = WritableRaster.createWritableRaster(sm, dataBuffer, new Point(0, 0));
-        // Create the original image
-        image = new BufferedImage(cm, raster, false, properties);
-        launcher(() -> updateDisplay());
-    }
-
     public void run() {
         while (!terminate) {
             long start = System.currentTimeMillis();
-            if (play) {
-                loadAndDisplayImage();
-                // Get the data from the native side that matches width & height
-            }
+            mediaPlayerData.updateImageData(data);
+            LOGGER.info("Presentation time is: " + mediaPlayerData.getPresentationTime() + " sec");
+            // Create data buffer
+            DataBufferByte dataBuffer = new DataBufferByte(data, width*height);
+            // Create writable raster
+            WritableRaster raster = WritableRaster.createWritableRaster(sm, dataBuffer, new Point(0, 0));
+            // Create the original image
+            image = new BufferedImage(cm, raster, false, properties);
+            launcher(() -> updateDisplay());
             // This does not measure the time to update the display
             double waitTime = REFRESH_PERIOD - (System.currentTimeMillis() - start)/TO_MILLIS;
             // If we need to wait

--- a/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
@@ -96,7 +96,9 @@ public class ImageCanvasPlayerThread extends Thread {
         while (!terminate) {
             long start = System.currentTimeMillis();
             mediaPlayerData.updateImageData(data);
-            LOGGER.info("Presentation time is: " + mediaPlayerData.getPresentationTime() + " sec");
+            //LOGGER.info("Presentation time is: " + mediaPlayerData.getPresentationTime() + " sec");
+            System.out.println("Presentation time is: " + mediaPlayerData.getPresentationTime() + " sec");
+
             // Create data buffer
             DataBufferByte dataBuffer = new DataBufferByte(data, width*height);
             // Create writable raster

--- a/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleJavaMediaPlayer.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/examples/SimpleJavaMediaPlayer.java
@@ -25,7 +25,7 @@ public class SimpleJavaMediaPlayer {
 
         // Set initial time and rate (which in the past triggered a flush on the queue and thus inaccurate timing)
         mediaPlayer.setStartTime(0);
-        //mediaPlayer.setRate(1f);
+        mediaPlayer.setRate(2f);
 
         // Open a JFrame to control the media player through key commands
         new JMediaPlayerControlFrame(mediaPlayer);

--- a/src/test/java/org/datavyu/plugins/ffmpeg/TestPlaybackRate.java
+++ b/src/test/java/org/datavyu/plugins/ffmpeg/TestPlaybackRate.java
@@ -25,11 +25,9 @@ public class TestPlaybackRate {
     // This movie is about 30MB has 640 x 360 pixels @ 29.97 fps with 2.5 min play time
     private static final String TEST_MOVIE_PATH = "http://www.html5videoplayer.net/videos/toystory.mp4";
 
-    private static final float LOWER_PERCENTAGE = -10f; // -10 percent
+    private static final float LOWER_PERCENTAGE = -2f; // -2 percent
 
-    private static final float UPPER_PERCENTAGE = +10f; // +10 percent
-
-    private static final double MEASUREMENT_DURATION_IN_SEC = 10; // 10 seconds
+    private static final float UPPER_PERCENTAGE = +2f; // +2 percent
 
     private static final double TO_MILLI = 1000;
 
@@ -87,10 +85,10 @@ public class TestPlaybackRate {
     }};
 
     private List<Pair<TimeInterval, Float>> parameters = new ArrayList<Pair<TimeInterval, Float>>(){{
-        //add(new Pair<>(new TimeInterval(0, 20), 0.5f));
-        //add(new Pair<>(new TimeInterval(0, 20), 1f));
+        add(new Pair<>(new TimeInterval(0, 20), 0.5f));
+        add(new Pair<>(new TimeInterval(0, 20), 1f));
         add(new Pair<>(new TimeInterval(0, 20), 2f));
-        //add(new Pair<>(new TimeInterval(0, 20), 4f));
+        add(new Pair<>(new TimeInterval(0, 20), 4f));
     }};
 
     private static double diffInPercent(double actual, double expected) {
@@ -100,7 +98,7 @@ public class TestPlaybackRate {
     @BeforeMethod
     public void setup() throws IOException {
         Configurator.setRootLevel(Level.INFO);
-        movieFiles.add(copyToLocalTmp(new URL(TEST_MOVIE_PATH)));
+        //movieFiles.add(copyToLocalTmp(new URL(TEST_MOVIE_PATH)));
         movieFiles.add("C:\\Users\\Florian\\Nature_30fps_1080p.mp4");
     }
 
@@ -127,7 +125,6 @@ public class TestPlaybackRate {
                             + (System.nanoTime() - startTime)/1e6 + " ms");
 
                     mediaPlayer.setStartTime(start);
-
                     startTime = System.nanoTime();
                     mediaPlayer.setRate(rate);
                     mediaPlayer.play();


### PR DESCRIPTION
Fix time at playback rate != 1x
    - Removed play/step from image canvas player thread
    - Removed seek optimization (when difference is small -> no seek)
    - Moved toggle (when step & pause) into display block
    - Use audio clock because it is more granular than the audio or video
    clock
 Switch from logger to System.out to see output in datavyu