### PR TITLE
Task dvd 529

### DIFF
--- a/src/main/cpp/FFplay.vcxproj
+++ b/src/main/cpp/FFplay.vcxproj
@@ -143,7 +143,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="FfmpegSdlAvPlayback.cpp" />
-    <ClCompile Include="ffplay.cpp" />
+    <ClCompile Include="player.cpp" />
     <ClCompile Include="MpvAvPlayback.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/main/cpp/FFplay.vcxproj.filters
+++ b/src/main/cpp/FFplay.vcxproj.filters
@@ -15,13 +15,13 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="ffplay.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="FfmpegSdlAvPlayback.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MpvAvPlayback.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="player.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/main/cpp/FfmpegAvPlayback.cpp
+++ b/src/main/cpp/FfmpegAvPlayback.cpp
@@ -1,6 +1,8 @@
 #include "FfmpegAvPlayback.h"
 #include "MediaPlayerErrors.h"
 
+bool FfmpegAvPlayback::kEnableShowStatus = true;
+
 void FfmpegAvPlayback::stream_toggle_pause() {
 	
 	// Get all the clocks

--- a/src/main/cpp/FfmpegAvPlayback.h
+++ b/src/main/cpp/FfmpegAvPlayback.h
@@ -22,6 +22,7 @@ protected:
 	void set_frame_timer(int newFrame_timer);
 	void set_force_refresh(int refresh);
 	double vp_duration(Frame *vp, Frame *nextvp, double max_frame_duration);
+	static bool kEnableShowStatus;
 public:
 	FfmpegAvPlayback();
 	int Init(const char *filename, AVInputFormat *iformat, int audio_buffer_size);

--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -178,7 +178,7 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
 		}
 	}
 
-	if (ENABLE_SHOW_STATUS) {
+	if (kEnableShowStatus) {
 		static int64_t last_time;
 		int64_t cur_time;
 		int aqsize, vqsize, sqsize;

--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -29,13 +29,13 @@ int FfmpegJavaAvPlayback::Init(const char * filename, AVInputFormat * iformat) {
 	}
 
 	pVideoState->set_destroy_callback([this] {
-		this->destroy();
+		destroy();
 	});
 
 	// TODO: Clean-up this callback as the first three parameters are not used here
 	pVideoState->set_audio_open_callback([this](int64_t wanted_channel_layout, int wanted_nb_channels,
 		int wanted_sample_rate, struct AudioParams *audio_hw_params) {
-		return this->audio_open(wanted_channel_layout, wanted_nb_channels, wanted_sample_rate, audio_hw_params);
+		return audio_open(wanted_channel_layout, wanted_nb_channels, wanted_sample_rate, audio_hw_params);
 	});
 
 
@@ -56,11 +56,10 @@ int FfmpegJavaAvPlayback::audio_open(int64_t wanted_channel_layout, int wanted_n
 }
 
 void FfmpegJavaAvPlayback::destroy() {
-	// stop_display_loop(); // only necessary when using as library -- has no effect otherwise
+
 	sws_freeContext(img_convert_ctx);
 
-	if (pVideoState)
-		pVideoState->stream_close();
+	delete pVideoState;
 
 #if CONFIG_VIDEO_FILTER
 	//av_freep(&vfilters_list);
@@ -179,7 +178,7 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
 		}
 	}
 
-	if (show_status) {
+	if (ENABLE_SHOW_STATUS) {
 		static int64_t last_time;
 		int64_t cur_time;
 		int aqsize, vqsize, sqsize;

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -555,8 +555,7 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
 				stream_toggle_pause();
 		}
 	}
-	//force_refresh = 0;
-	if (show_status) {
+	if (ENABLE_SHOW_STATUS) {
 		static int64_t last_time;
 		int64_t cur_time;
 		int aqsize, vqsize, sqsize;
@@ -663,36 +662,39 @@ void FfmpegSdlAvPlayback::InitSdl() {
 
 void FfmpegSdlAvPlayback::destroy() {
 
-	// only necessary when using as library -- has no effect otherwise
 	stop_display_loop();
 
-	// close the VideoState Stream
-	if (pVideoState)
-		pVideoState->stream_close();
-
-	if (audio_dev)
+	if (audio_dev) {
 		closeAudioDevice();
-	
-	// Cleanup textures
-	if (vis_texture)
-		SDL_DestroyTexture(vis_texture);
+	}
 
-	if (vid_texture)
+	delete pVideoState;
+
+	// Cleanup textures
+	if (vis_texture) {
+		SDL_DestroyTexture(vis_texture);
+	}
+
+	if (vid_texture) {
 		SDL_DestroyTexture(vid_texture);
+	}
 	
-	if (sub_texture)
+	if (sub_texture) {
 		SDL_DestroyTexture(sub_texture);
+	}
 
 	// Cleanup resampling
 	sws_freeContext(img_convert_ctx);
 	sws_freeContext(sub_convert_ctx);
 
 	// Cleanup SDL components
-	if (renderer)
+	if (renderer) {
 		SDL_DestroyRenderer(renderer);
+	}
 
-	if (window)
+	if (window) {
 		SDL_DestroyWindow(window);
+	}
 
 	avformat_network_deinit();
 
@@ -763,9 +765,6 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 			case SDLK_s: // S: Step to next frame
 				step_to_next_frame();
 				break;
-			case SDLK_a:
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_AUDIO);
-				break;
 			case SDLK_KP_PLUS:
 				if (pVideoState->set_rate(rate * 2)) {
 					av_log(NULL, AV_LOG_ERROR, "Rate %f unavailable\n", rate * 2);
@@ -779,17 +778,6 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 				} else {
 					rate /= 2;
 				}
-				break;
-			case SDLK_v:
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_VIDEO);
-				break;
-			case SDLK_c:
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_VIDEO);
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_AUDIO);
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_SUBTITLE);
-				break;
-			case SDLK_t:
-				pVideoState->stream_cycle_channel(AVMEDIA_TYPE_SUBTITLE);
 				break;
 			case SDLK_PAGEUP:
 				if (pVideoState->get_ic()->nb_chapters <= 1) {

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -555,7 +555,7 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
 				stream_toggle_pause();
 		}
 	}
-	if (ENABLE_SHOW_STATUS) {
+	if (kEnableShowStatus) {
 		static int64_t last_time;
 		int64_t cur_time;
 		int aqsize, vqsize, sqsize;

--- a/src/main/cpp/FfmpegSdlAvPlayback.h
+++ b/src/main/cpp/FfmpegSdlAvPlayback.h
@@ -9,6 +9,8 @@ extern "C" {
 	#include <SDL2/SDL.h>
 	#include <SDL2/SDL_thread.h>
 }
+/* Minimum SDL audio buffer size, in samples. */
+#define SDL_AUDIO_MIN_BUFFER_SIZE 512
 
 /* Calculate actual buffer size keeping in mind not cause too frequent audio callbacks */
 #define SDL_AUDIO_MAX_CALLBACKS_PER_SEC 30

--- a/src/main/cpp/MpvAvPlayback.cpp
+++ b/src/main/cpp/MpvAvPlayback.cpp
@@ -329,11 +329,6 @@ void MpvAvPlayback::init_and_event_loop(const char *filename)
 		int redraw = 0;
 		switch (event.type) {
 		case SDL_KEYDOWN:
-			if (exit_on_keydown) {
-				pPlayer->Destroy();
-				exit(0); // need to exit here to avoid joinable exception
-				break;
-			}
 			switch (event.key.keysym.sym) {
 			case SDLK_ESCAPE:
 				pPlayer->Destroy();

--- a/src/main/cpp/TestClock.cpp
+++ b/src/main/cpp/TestClock.cpp
@@ -1,6 +1,4 @@
 #include "gtest/gtest.h"
-
-#include "gtest/gtest.h";
 #include "Clock.h"
 
 #include <limits>
@@ -8,13 +6,13 @@
 #include <thread>
 
 
-TEST (ClockTest, CreateDeleteClockTest) {
+TEST (ClockTest, CreateAndDeleteClockTest) {
     int serial = 0;
     Clock clock(&serial);
 	ASSERT_EQ(clock.get_serial(), -1.0);
 }
 
-TEST (ClockTest, SetGetClockTest) {
+TEST (ClockTest, SetGetTimeTest) {
 	// Create a clock
 	int serial = 0;
 	Clock clock(&serial);
@@ -34,7 +32,7 @@ TEST (ClockTest, SetGetClockTest) {
 	double speed = 1.0;
 	double newTime = av_gettime_relative() / MICRO;
 
-	// Note, that in this setup ptsDrift ~= 0
-	// ASSERT LESS THAN
-	ASSERT_LT(fabs(clock.get_time() - (newTime - (newTime - time) * (1.0 - speed))), std::numeric_limits<float>::epsilon());
+	// ASSERT LESS THAN, the expired time does not matter, only the setTime changes 
+	// the clock's time
+	ASSERT_LT(fabs(clock.get_time() - time), std::numeric_limits<float>::epsilon());
 }

--- a/src/main/cpp/VideoState.h
+++ b/src/main/cpp/VideoState.h
@@ -34,9 +34,6 @@ extern "C" {
 	#include <assert.h>
 }
 
-/* Minimum SDL audio buffer size, in samples. */
-#define SDL_AUDIO_MIN_BUFFER_SIZE 512
-
 #define MAX_QUEUE_SIZE (15 * 1024 * 1024)
 #define MIN_FRAMES 25
 #define EXTERNAL_CLOCK_MIN_FRAMES 2
@@ -54,11 +51,6 @@ extern "C" {
 /* maximum audio speed change to get correct sync */
 #define SAMPLE_CORRECTION_PERCENT_MAX 10
 
-/* external clock speed adjustment constants for realtime sources based on buffer fullness */
-#define EXTERNAL_CLOCK_SPEED_MIN  0.900
-#define EXTERNAL_CLOCK_SPEED_MAX  1.010
-#define EXTERNAL_CLOCK_SPEED_STEP 0.001
-
 /* we use about AUDIO_DIFF_AVG_NB A-V differences to make the average */
 #define AUDIO_DIFF_AVG_NB   20
 
@@ -68,14 +60,6 @@ extern "C" {
 #define FRAME_QUEUE_SIZE FFMAX(SAMPLE_QUEUE_SIZE, FFMAX(VIDEO_PICTURE_QUEUE_SIZE, SUBPICTURE_QUEUE_SIZE))
 
 #define MY_AV_TIME_BASE_Q av_make_q(1, AV_TIME_BASE)
-
-// fixed point to double
-#define CONV_FP(x) ((double) (x)) / (1 << 16)
-
-#define ENABLE_SHOW_STATUS 1
-#define ENABLE_FAST_DECODE 0
-// generate missing pts for audio if it means parsing future frames
-#define ENABLE_GENERATE_PTS 0
 
 enum {
 	AV_SYNC_AUDIO_MASTER, /* default choice */
@@ -112,7 +96,6 @@ private:
 	int64_t	seek_pos;
 	int64_t seek_rel;
 	int	read_pause_return;
-	int realtime;
 	int	av_sync_type;
 	int fps;
 	int subtitle_stream;
@@ -219,8 +202,6 @@ private:
 	/* From cmd utils*/
 	AVDictionary **setup_find_stream_info_opts(AVFormatContext *s, AVDictionary *codec_opts);
 
-	int is_realtime(AVFormatContext *s);
-
 	/* return the wanted number of samples to get better sync if sync_type is video
 	* or external master clock */
 	int synchronize_audio(int nb_samples);
@@ -240,6 +221,10 @@ private:
 	std::function<void()> destroy_callback; // TODO(fraudies): Possibly clean-up through destructor
 	std::function<void()> step_to_next_frame_callback;
 	VideoState(int audio_buffer_size);
+
+	static bool kEnableShowFormat;
+	static bool kEnableFastDecode;
+	static bool kEnableGeneratePts;
 public:
 	static VideoState* create_video_state(int audio_buffer_size);
 

--- a/src/main/cpp/player.cpp
+++ b/src/main/cpp/player.cpp
@@ -28,12 +28,12 @@ int main(int argc, char **argv) {
 	/******************************************************
 	* Uncomment this part to test the ffmpeg player
 	******************************************************/
-	//runFFmpegPlayer(input_filename, file_iformat);
+	runFFmpegPlayer(input_filename, file_iformat);
 
 	/******************************************************
 	* Uncomment this part to test the mpv player
 	******************************************************/
-	runMpvPlayer(input_filename);
+	//runMpvPlayer(input_filename);
 
 	return 0;
 }


### PR DESCRIPTION
Remove unused code
    - Cycle through channel code
    - Remove logic for custom codec (for decode) passed through command line (which we don't have)
    - Remove lowres flag (unused)
    - Remove decode cmd
    - Replace show status, fast decode, generate pts by ENABLE flags
    - Logic of stream_close moved to ~VideoState, fix for free up of VideoState
Fix clock test