### PR TITLE
Remove globals, macros from VideoState

### DIFF
--- a/src/main/cpp/Clock.cpp
+++ b/src/main/cpp/Clock.cpp
@@ -32,11 +32,11 @@ void Clock::set_time(double newTime, int newSerial) {
 	serial = newSerial;
 }
 
-void Clock::sync_slave_to_master(Clock *slave, Clock *master) {
+void Clock::sync_slave_to_master(Clock *slave, Clock *master, double noSyncThreshold) {
 	double master_time = master->get_time();
 	double slave_time = slave->get_time();
 	if (!isnan(slave_time) && (isnan(master_time) 
-		|| fabs(master_time - slave_time) > AV_NOSYNC_THRESHOLD)) {
+		|| fabs(master_time - slave_time) > noSyncThreshold)) {
 		av_log(NULL, AV_LOG_TRACE, "Sync %7.2f to %7.2f\n", slave_time, master_time);
 		slave->set_time(slave_time, master->serial);
 	}

--- a/src/main/cpp/Clock.h
+++ b/src/main/cpp/Clock.h
@@ -7,7 +7,6 @@ extern "C" {
 #ifndef CLOCK_H_
 #define CLOCK_H_
 
-#define AV_NOSYNC_THRESHOLD 10 // 10 sec
 #define MICRO 1000000.0
 
 // Clock to keep decoding in sync
@@ -24,14 +23,10 @@ class Clock {
         double time;				// clock time
         int serial;					// clock is based on a packet with this serial
         const int *queueSerial;	// pointer to the current packet queue serial, used for obsolete clock detection
+		double noSyncThreshold;
+
 		inline bool is_seek() const { return *queueSerial != serial; }
     public:
-        enum {
-            AV_SYNC_AUDIO_MASTER, // default
-            AV_SYNC_VIDEO_MASTER,
-            AV_SYNC_EXTERNAL_CLOCK, // synchronize to an external clock
-        };
-
 		Clock(const int *queue_serial);
 
 		Clock();
@@ -42,7 +37,7 @@ class Clock {
 
 		void set_time(double newTime, int newSerial);
 
-		static void sync_slave_to_master(Clock *c, Clock *slave);
+		static void sync_slave_to_master(Clock *c, Clock *slave, double noSyncThreshold);
 };
 
 #endif CLOCK_H_

--- a/src/main/cpp/FfmpegAvPlayback.cpp
+++ b/src/main/cpp/FfmpegAvPlayback.cpp
@@ -45,7 +45,7 @@ int FfmpegAvPlayback::Init(const char *filename, AVInputFormat *iformat, int aud
 
 FfmpegAvPlayback::~FfmpegAvPlayback() {}
 
-void FfmpegAvPlayback::set_player_state_callback_func(PlayerStateCallback callback, const std::function<void()>& func) {
+void FfmpegAvPlayback::set_player_state_callback_func(VideoState::PlayerStateCallback callback, const std::function<void()>& func) {
 	pVideoState->set_player_state_callback_func(callback, func);
 }
 

--- a/src/main/cpp/FfmpegAvPlayback.h
+++ b/src/main/cpp/FfmpegAvPlayback.h
@@ -27,7 +27,7 @@ public:
 	FfmpegAvPlayback();
 	int Init(const char *filename, AVInputFormat *iformat, int audio_buffer_size);
 	virtual ~FfmpegAvPlayback();
-	virtual void set_player_state_callback_func(PlayerStateCallback callback, const std::function<void()>& func);
+	virtual void set_player_state_callback_func(VideoState::PlayerStateCallback callback, const std::function<void()>& func);
 	virtual void play();
 	virtual void stop();
 	virtual void toggle_pause();

--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -145,7 +145,7 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
 			}
 
 			frame_timer += delay;
-			if (delay > 0 && time - frame_timer > AV_SYNC_THRESHOLD_MAX)
+			if (delay > 0 && time - frame_timer > VideoState::kAvSyncThresholdMax)
 				frame_timer = time;
 
 			std::unique_lock<std::mutex> locker(pVideoState->get_pPictq()->get_mutex());

--- a/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlaybackPipline.cpp
@@ -23,25 +23,25 @@ uint32_t FfmpegJavaAvPlaybackPipline::Init(const char * input_file) {
 	}
 
 	// Assign the callback functions
-	pJavaPlayback->set_player_state_callback_func(TO_UNKNOWN, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_UNKNOWN, [this] {
 		this->UpdatePlayerState(Unknown);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_READY, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_READY, [this] {
 		this->UpdatePlayerState(Ready);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_PLAYING, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_PLAYING, [this] {
 		this->UpdatePlayerState(Playing);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_PAUSED, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_PAUSED, [this] {
 		this->UpdatePlayerState(Paused);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_STOPPED, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_STOPPED, [this] {
 		this->UpdatePlayerState(Stopped);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_STALLED, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_STALLED, [this] {
 		this->UpdatePlayerState(Stalled);
 	});
-	pJavaPlayback->set_player_state_callback_func(TO_FINISHED, [this] {
+	pJavaPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_FINISHED, [this] {
 		this->UpdatePlayerState(Finished);
 	});
 

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -468,7 +468,7 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
 			}
 
 			frame_timer += delay;
-			if (delay > 0 && time - frame_timer > AV_SYNC_THRESHOLD_MAX)
+			if (delay > 0 && time - frame_timer > VideoState::kAvSyncThresholdMax)
 				frame_timer = time;
 
 			std::unique_lock<std::mutex> locker(pVideoState->get_pPictq()->get_mutex());
@@ -733,7 +733,7 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 				incr = -5.0;
 			do_seek:
 				//TODO FIX SEEK BY BYTES BUG
-				if (seek_by_bytes) {
+				if (VideoState::kEnableSeekByBytes) {
 					pos = -1;
 					if (pos < 0 && pVideoState->get_video_stream() >= 0)
 						pos = pVideoState->get_pPictq()->last_pos();
@@ -791,7 +791,7 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
 					break;
 				x = event.motion.x;
 			}
-			if (seek_by_bytes || pVideoState->get_ic()->duration <= 0) {
+			if (VideoState::kEnableSeekByBytes || pVideoState->get_ic()->duration <= 0) {
 				uint64_t size = avio_size(pVideoState->get_ic()->pb);
 				pVideoState->stream_seek(size*x / width, 0, 1);
 			}

--- a/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
@@ -28,25 +28,25 @@ uint32_t FfmpegSdlAvPlaybackPipeline::Init(const char * input_file) {
 	}
 
 	// Assign the callback functions	
-	pSdlPlayback->set_player_state_callback_func(TO_UNKNOWN, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_UNKNOWN, [this] {
 		this->UpdatePlayerState(Unknown);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_READY, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_READY, [this] {
 		this->UpdatePlayerState(Ready);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_PLAYING, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_PLAYING, [this] {
 		this->UpdatePlayerState(Playing);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_PAUSED, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_PAUSED, [this] {
 		this->UpdatePlayerState(Paused);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_STOPPED, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_STOPPED, [this] {
 		this->UpdatePlayerState(Stopped);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_STALLED, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_STALLED, [this] {
 		this->UpdatePlayerState(Stalled);
 	});
-	pSdlPlayback->set_player_state_callback_func(TO_FINISHED, [this] {
+	pSdlPlayback->set_player_state_callback_func(VideoState::PlayerStateCallback::TO_FINISHED, [this] {
 		this->UpdatePlayerState(Finished);
 	});
 	

--- a/src/main/cpp/FrameQueue.h
+++ b/src/main/cpp/FrameQueue.h
@@ -9,9 +9,6 @@ extern "C" {
 #ifndef FRAME_QUEUE_H_
 #define FRAME_QUEUE_H_
 
-#define VIDEO_PICTURE_QUEUE_SIZE 3
-#define SAMPLE_QUEUE_SIZE 9
-
 // Common struct for handling decoded data and allocated buffers
 typedef struct Frame {
     AVFrame *frame;

--- a/src/main/cpp/TestClock.cpp
+++ b/src/main/cpp/TestClock.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <thread>
 
+// TODO(fraudies): Add test for sync method
 
 TEST (ClockTest, CreateAndDeleteClockTest) {
     int serial = 0;

--- a/src/main/cpp/TestFrameQueue.cpp
+++ b/src/main/cpp/TestFrameQueue.cpp
@@ -5,6 +5,9 @@
 
 #include <thread>
 
+#define SAMPLE_QUEUE_SIZE 9
+#define VIDEO_PICTURE_QUEUE_SIZE 3
+
 TEST(FrameQueueTest, CreateDeleteFrameQueueTest ) {
 	PacketQueue packetQueue;
     FrameQueue* frameQueue = FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);


### PR DESCRIPTION
- Moved start_time, play_time, loop as attributes in VideoState
- Moved seek_by_bytes as constant to VideoState
- Moved enums for PlayerStateCallback and AvSyncType into VideoState
- Converted macros from VideoState into constants in VideoState