### PR TITLE
Change to google formatting that clang tool won't format

### DIFF
--- a/src/main/cpp/AudioVideoFormats.cpp
+++ b/src/main/cpp/AudioVideoFormats.cpp
@@ -6,18 +6,18 @@ extern "C" {
 
 AudioFormat::AudioFormat() {}
 
-void AudioFormat::toAudioParams(AudioParams *pAudioParams) const {
-  pAudioParams->channels = channels;
-  pAudioParams->frame_size = frameSize;
-  pAudioParams->freq = sampleRate;
-  pAudioParams->bytes_per_sec = frameRate;
-  pAudioParams->channel_layout = av_get_default_channel_layout(channels);
+void AudioFormat::ToAudioParams(AudioParams *pAudioParams) const {
+  pAudioParams->num_channels_ = num_channels_;
+  pAudioParams->frame_size_ = frame_size_;
+  pAudioParams->frequency_ = sample_rate_;
+  pAudioParams->bytes_per_sec_ = frame_rate_;
+  pAudioParams->channel_layout_ = av_get_default_channel_layout(num_channels_);
   // TODO(fraudies): Support more formats (currently not necessary because of
-  // the javax SoundLine
-  if (strcmp("PCM_UNSIGNED", encoding.c_str()) == 0) {
-    pAudioParams->fmt = AV_SAMPLE_FMT_U8;
-  } else if (strcmp("PCM_SIGNED", encoding.c_str()) == 0) {
-    pAudioParams->fmt = AV_SAMPLE_FMT_S16;
+  // the javax SoundLine does not support more formats
+  if (strcmp("PCM_UNSIGNED", encoding_name_.c_str()) == 0) {
+    pAudioParams->sample_format_ = AV_SAMPLE_FMT_U8;
+  } else if (strcmp("PCM_SIGNED", encoding_name_.c_str()) == 0) {
+    pAudioParams->sample_format_ = AV_SAMPLE_FMT_S16;
   }
 }
 

--- a/src/main/cpp/AudioVideoFormats.h
+++ b/src/main/cpp/AudioVideoFormats.h
@@ -9,31 +9,31 @@ extern "C" {
 
 // TODO(fraudies): Consolidate AudioParams and AudioFormat
 typedef struct AudioParams {
-  int freq;
-  int channels;
-  int64_t channel_layout;
-  enum AVSampleFormat fmt;
-  int frame_size;
-  int bytes_per_sec;
+  int frequency_;
+  int num_channels_;
+  int64_t channel_layout_;
+  enum AVSampleFormat sample_format_;
+  int frame_size_;
+  int bytes_per_sec_;
 } AudioParams;
 
 class AudioFormat {
 public:
-  std::string encoding;
-  float sampleRate;
-  int sampleSizeInBits;
-  int channels;
-  int frameSize;
-  float frameRate;
-  bool bigEndian;
+  std::string encoding_name_;
+  float sample_rate_;
+  int sample_size_in_bits_;
+  int num_channels_;
+  int frame_size_;
+  float frame_rate_;
+  bool is_big_endian_;
   AudioFormat();
-  void toAudioParams(AudioParams *pAudioParams) const;
+  void ToAudioParams(AudioParams *pAudioParams) const;
 };
 
 class PixelFormat {
 public:
-  AVPixelFormat type;
-  int numComponents;
+  AVPixelFormat pixel_format_;
+  int num_components_;
   PixelFormat();
 };
 

--- a/src/main/cpp/Clock.cpp
+++ b/src/main/cpp/Clock.cpp
@@ -5,37 +5,37 @@ extern "C" {
 }
 
 Clock::Clock(const int *queue_serial)
-    : time(0.0), serial(-1), queueSerial(queue_serial) {
-  set_time(NAN, -1);
+    : time(0.0), serial(-1), p_serial_(queue_serial) {
+  SetTime(NAN, -1);
 }
 
-Clock::Clock() : time(0.0), serial(-1), queueSerial(&serial) {
-  set_time(NAN, -1);
+Clock::Clock() : time(0.0), serial(-1), p_serial_(&serial) {
+  SetTime(NAN, -1);
 }
 
-double Clock::get_time() const {
-  if (is_seek()) {
+double Clock::GetTime() const {
+  if (SerialNoMatch()) {
     return NAN;
   }
   return time;
 }
 
-void Clock::set_time(double newTime, int newSerial) {
+void Clock::SetTime(double newTime, int newSerial) {
   if (!isnan(newTime)) {
     time = newTime;
   }
   serial = newSerial;
 }
 
-void Clock::sync_slave_to_master(Clock *slave, Clock *master,
+void Clock::SyncSlaveToMaster(Clock *slave, Clock *master,
                                  double noSyncThreshold) {
-  double master_time = master->get_time();
-  double slave_time = slave->get_time();
+  double master_time = master->GetTime();
+  double slave_time = slave->GetTime();
   if (!isnan(slave_time) &&
       (isnan(master_time) ||
        fabs(master_time - slave_time) > noSyncThreshold)) {
     av_log(NULL, AV_LOG_TRACE, "Sync %7.2f to %7.2f\n", slave_time,
            master_time);
-    slave->set_time(slave_time, master->serial);
+    slave->SetTime(slave_time, master->serial);
   }
 }

--- a/src/main/cpp/Clock.h
+++ b/src/main/cpp/Clock.h
@@ -19,28 +19,27 @@ extern "C" {
 // code design at the cost of performance).
 //
 class Clock {
-private:
-  double time;            // clock time
-  int serial;             // clock is based on a packet with this serial
-  const int *queueSerial; // pointer to the current packet queue serial, used
-                          // for obsolete clock detection
-  double noSyncThreshold;
-
-  inline bool is_seek() const { return *queueSerial != serial; }
-
 public:
   Clock(const int *queue_serial);
 
   Clock();
 
-  double get_time() const; // for stream time, depends on rate
+  double GetTime() const; // for stream time, depends on rate
 
-  inline double get_serial() const { return serial; }
+  inline double GetSerial() const { return serial; }
 
-  void set_time(double newTime, int newSerial);
+  void SetTime(double newTime, int newSerial);
 
-  static void sync_slave_to_master(Clock *c, Clock *slave,
-                                   double noSyncThreshold);
+  static void SyncSlaveToMaster(Clock *master, Clock *slave,
+                                double noSyncThreshold);
+
+private:
+  double time;          // clock time
+  int serial;           // clock is based on a packet with this serial
+  const int *p_serial_; // pointer to the current packet queue serial,
+                        // used for obsolete clock detection
+
+  inline bool SerialNoMatch() const { return *p_serial_ != serial; }
 };
 
 #endif CLOCK_H_

--- a/src/main/cpp/Decoder.cpp
+++ b/src/main/cpp/Decoder.cpp
@@ -2,62 +2,64 @@
 
 Decoder::Decoder(AVCodecContext *avctx, PacketQueue *queue,
                  std::condition_variable *empty_queue_cond)
-    : avctx(avctx), queue(queue), empty_queue_cond(empty_queue_cond),
-      pkt_serial(-1), finished(0), packet_pending(0), decoder_reorder_pts(0),
-      start_pts(AV_NOPTS_VALUE), start_pts_tb(av_make_q(0, 0)), next_pts(0),
-      next_pts_tb(av_make_q(0, 0)), decoder_tid(nullptr) {
+    : p_codec_context_(avctx), p_packet_queue_(queue),
+      p_is_empty_condition_(empty_queue_cond), serial_(-1), is_finished_(false),
+      is_packet_pending_(false), do_reorder_(false),
+      start_pts_(AV_NOPTS_VALUE), start_pts_timebase_(av_make_q(0, 0)),
+      next_pts_(0), next_pts_timebase_(av_make_q(0, 0)),
+      p_decoder_thread_(nullptr) {
   // Note, that pkt will need to be initialized for the case when decode_frame
   // is never run Sidenote: the move ref code will clean this initialization
-  av_init_packet(&pkt);
+  av_init_packet(&packet_);
 }
 
 Decoder::~Decoder() {
-  av_packet_unref(&pkt);
-  // TODO(fraudies): Clean-up design, move this de-allocation to the VideoState
-  // (where it is initialized)
-  avcodec_free_context(&avctx);
+  av_packet_unref(&packet_);
+  // TODO(fraudies): Move initialization of codec context into Decoder from VideoState
+	avcodec_free_context(&p_codec_context_);
 }
 
-int Decoder::decode_frame(AVFrame *frame) {
+int Decoder::Decode(AVFrame *frame) {
   int ret = AVERROR(EAGAIN);
 
   for (;;) {
-    AVPacket pkt;
+    AVPacket packet;
 
-    if (queue->get_serial() == pkt_serial) {
+    if (p_packet_queue_->GetSerial() == serial_) {
       do {
-        if (queue->is_abort_request())
+        if (p_packet_queue_->IsAbortRequested())
           return -1;
 
-        switch (avctx->codec_type) {
+        switch (p_codec_context_->codec_type) {
         case AVMEDIA_TYPE_VIDEO:
-          ret = avcodec_receive_frame(avctx, frame);
+          ret = avcodec_receive_frame(p_codec_context_, frame);
           if (ret >= 0) {
-            if (decoder_reorder_pts == -1) {
+            if (do_reorder_ == -1) {
               frame->pts = frame->best_effort_timestamp;
-            } else if (!decoder_reorder_pts) {
+            } else if (!do_reorder_) {
               frame->pts = frame->pkt_dts;
             }
           }
           break;
         case AVMEDIA_TYPE_AUDIO:
-          ret = avcodec_receive_frame(avctx, frame);
+          ret = avcodec_receive_frame(p_codec_context_, frame);
           if (ret >= 0) {
             AVRational tb = av_make_q(1, frame->sample_rate);
             if (frame->pts != AV_NOPTS_VALUE)
-              frame->pts = av_rescale_q(frame->pts, avctx->pkt_timebase, tb);
-            else if (next_pts != AV_NOPTS_VALUE)
-              frame->pts = av_rescale_q(next_pts, next_pts_tb, tb);
+              frame->pts =
+                  av_rescale_q(frame->pts, p_codec_context_->pkt_timebase, tb);
+            else if (next_pts_ != AV_NOPTS_VALUE)
+              frame->pts = av_rescale_q(next_pts_, next_pts_timebase_, tb);
             if (frame->pts != AV_NOPTS_VALUE) {
-              next_pts = frame->pts + frame->nb_samples;
-              next_pts_tb = tb;
+              next_pts_ = frame->pts + frame->nb_samples;
+              next_pts_timebase_ = tb;
             }
           }
           break;
         }
         if (ret == AVERROR_EOF) {
-          finished = pkt_serial;
-          avcodec_flush_buffers(avctx);
+          is_finished_ = serial_;
+          avcodec_flush_buffers(p_codec_context_);
           return 0;
         }
         if (ret >= 0)
@@ -66,62 +68,56 @@ int Decoder::decode_frame(AVFrame *frame) {
     }
 
     do {
-      if (queue->get_nb_packets() == 0)
-        empty_queue_cond->notify_one();
-      if (packet_pending) {
-        av_packet_move_ref(&pkt, &this->pkt);
-        packet_pending = 0;
+      if (p_packet_queue_->getNumberOfPackets() == 0)
+        p_is_empty_condition_->notify_one();
+      if (is_packet_pending_) {
+        av_packet_move_ref(&packet, &packet_);
+        is_packet_pending_ = false;
       } else {
-        if (queue->get(&pkt, 1, &pkt_serial) < 0)
+        if (p_packet_queue_->Get(&packet, 1, &serial_) < 0)
           return -1;
       }
-    } while (queue->get_serial() != pkt_serial);
+    } while (p_packet_queue_->GetSerial() != serial_);
 
-    if (queue->is_flush_packet(pkt)) {
-      avcodec_flush_buffers(avctx);
-      finished = 0;
-      next_pts = start_pts;
-      next_pts_tb = start_pts_tb;
+    if (p_packet_queue_->IsFlushPacket(packet)) {
+      avcodec_flush_buffers(p_codec_context_);
+      is_finished_ = 0;
+      next_pts_ = start_pts_;
+      next_pts_timebase_ = start_pts_timebase_;
     } else {
-      if (avctx->codec_type != AVMEDIA_TYPE_SUBTITLE &&
-          avcodec_send_packet(avctx, &pkt) == AVERROR(EAGAIN)) {
-        av_log(avctx, AV_LOG_ERROR,
+      if (p_codec_context_->codec_type != AVMEDIA_TYPE_SUBTITLE &&
+          avcodec_send_packet(p_codec_context_, &packet) == AVERROR(EAGAIN)) {
+        av_log(p_codec_context_, AV_LOG_ERROR,
                "Receive_frame and send_packet both returned EAGAIN, which is "
                "an API violation.\n");
-        packet_pending = 1;
-        av_packet_move_ref(&this->pkt, &pkt);
+        is_packet_pending_ = true;
+        av_packet_move_ref(&packet_, &packet);
       }
-      av_packet_unref(&pkt);
+      av_packet_unref(&packet);
     }
   }
 }
 
-void Decoder::set_start_pts(int64_t start_pts) { this->start_pts = start_pts; }
-
-void Decoder::set_start_pts_tb(AVRational start_pts_tb) {
-  this->start_pts_tb = start_pts_tb;
-}
-
-int Decoder::start(const std::function<void()> &decoding) {
-  queue->start();
-  decoder_tid = new std::thread([decoding] { decoding(); });
-  if (!decoder_tid) {
+int Decoder::Start(const std::function<void()> &decoding) {
+  p_packet_queue_->Start();
+  p_decoder_thread_ = new std::thread([decoding] { decoding(); });
+  if (!p_decoder_thread_) {
     av_log(NULL, AV_LOG_ERROR, "Can't create thread");
     return AVERROR(ENOMEM);
   }
   return 0;
 }
 
-void Decoder::abort(FrameQueue *fq) {
+void Decoder::Stop(FrameQueue *frame_queue) {
   // TODO(fraudies): Cleanup this design by keeping frame queue and packet queue
   // together
-  queue->abort();
-  fq->signal();
+  p_packet_queue_->Abort();
+  frame_queue->Signal();
   // Take care of the case when we never called start
-  if (decoder_tid) {
-    decoder_tid->join();
-    delete decoder_tid;
-    decoder_tid = nullptr;
+  if (p_decoder_thread_) {
+    p_decoder_thread_->join();
+    delete p_decoder_thread_;
+    p_decoder_thread_ = nullptr;
   }
-  queue->flush();
+  p_packet_queue_->Flush();
 }

--- a/src/main/cpp/FFplay.vcxproj
+++ b/src/main/cpp/FFplay.vcxproj
@@ -78,6 +78,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>C:\Program Files\Java\jdk1.8.0_172\include\win32;C:\Program Files\Java\jdk1.8.0_172\include;C:\FFplay64\include;$(IncludePath)</IncludePath>
     <LibraryPath>C:\Program Files\Java\jdk1.8.0_172\lib;C:\FFplay64\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -105,7 +107,6 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;MPVMEDIAPLAYER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>SDL2.lib;SDL2main.lib;avutil.lib;avdevice.lib;avfilter.lib;avformat.lib;avcodec.lib;postproc.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/main/cpp/FfmpegAvPlayback.cpp
+++ b/src/main/cpp/FfmpegAvPlayback.cpp
@@ -3,118 +3,75 @@
 
 bool FfmpegAvPlayback::kEnableShowStatus = true;
 
-void FfmpegAvPlayback::stream_toggle_pause() {
+void FfmpegAvPlayback::TogglePause() {
 
   // Get all the clocks
-  Clock *pExtclk = pVideoState->get_pExtclk();
-  Clock *pVidclk = pVideoState->get_pVidclk();
-  Clock *pAudclk = pVideoState->get_pAudclk();
+  Clock *pExtclk = p_video_state_->get_pExtclk();
+  Clock *pVidclk = p_video_state_->get_pVidclk();
+  Clock *pAudclk = p_video_state_->get_pAudclk();
 
   // Update the video clock
-  if (pVideoState->get_paused()) {
-    set_frame_timer(get_frame_timer() + av_gettime_relative() / 1000000.0 -
-                    pVideoState->get_vidclk_last_set_time());
+  if (p_video_state_->get_paused()) {
+    SetFrameLastShownTime(GetFrameLastShownTime() +
+                          av_gettime_relative() / 1000000.0 -
+                          p_video_state_->get_vidclk_last_set_time());
     pVidclk->set_time(pVidclk->get_time(), pVidclk->get_serial());
   }
   // Update the external clock
   pExtclk->set_time(pExtclk->get_time(), pExtclk->get_serial());
 
   // Flip the paused flag on the clocks
-  bool flipped = !pVideoState->get_paused();
-  pVideoState->set_paused(flipped);
+  bool flipped = !p_video_state_->get_paused();
+  p_video_state_->set_paused(flipped);
 }
 
 FfmpegAvPlayback::FfmpegAvPlayback()
-    : pVideoState(nullptr), display_disable(0), width(0), height(0),
-      force_refresh(1), frame_drops_late(0), rdftspeed(0.02), last_vis_time(0) {
+    : p_video_state_(nullptr), display_disabled_(false), frame_width_(0), frame_height_(0),
+      force_refresh_(1), num_frame_drops_late_(0) {}
+
+int FfmpegAvPlayback::OpenVideo(const char *filename, AVInputFormat *iformat,
+                                int audio_buffer_size) {
+  return VideoState::OpenStream(&p_video_state_, filename, iformat, audio_buffer_size);
 }
 
-int FfmpegAvPlayback::Init(const char *filename, AVInputFormat *iformat,
-                           int audio_buffer_size) {
-  pVideoState = VideoState::stream_open(filename, iformat, audio_buffer_size);
-
-  if (!pVideoState) {
-    return ERROR_PLAYBACK_NULL;
-  }
-
-  return ERROR_NONE;
-}
-
-FfmpegAvPlayback::~FfmpegAvPlayback() {}
-
-void FfmpegAvPlayback::set_player_state_callback_func(
+void FfmpegAvPlayback::SetPlayerStateCallbackFunction(
     VideoState::PlayerStateCallback callback,
     const std::function<void()> &func) {
-  pVideoState->set_player_state_callback_func(callback, func);
+  p_video_state_->SetPlayerStateCallbackFunction(callback, func);
 }
 
-void FfmpegAvPlayback::play() {
-  if (pVideoState->get_paused()) {
-    toggle_pause();
-    pVideoState->set_stopped(false);
+void FfmpegAvPlayback::Play() {
+  if (p_video_state_->get_paused()) {
+    TogglePauseAndStopStep();
+    p_video_state_->set_stopped(false);
   }
 }
 
 // Stop and put the playback speed to 0x
 // Note the playback speed is not implemetnted yet
-void FfmpegAvPlayback::stop() {
-  if (!pVideoState->get_paused()) {
-    toggle_pause();
-    pVideoState->set_stopped(true);
+void FfmpegAvPlayback::Stop() {
+  if (!p_video_state_->get_paused()) {
+    TogglePauseAndStopStep();
+    p_video_state_->set_stopped(true);
   }
 }
 
 // pause and keep the playback speed.
 // Note the playback speed is not implemetnted yet
-void FfmpegAvPlayback::toggle_pause() {
-  stream_toggle_pause();
-  pVideoState->set_step(false);
+void FfmpegAvPlayback::TogglePauseAndStopStep() {
+  TogglePause();
+  p_video_state_->SetStepping(false);
 }
 
-void FfmpegAvPlayback::stream_seek(int64_t pos, int64_t rel,
-                                   int seek_by_bytes) {
-  pVideoState->stream_seek(pos, rel, seek_by_bytes);
-}
-
-double FfmpegAvPlayback::get_duration() const {
-  return pVideoState->get_duration();
-}
-
-double FfmpegAvPlayback::get_stream_time() const {
-  return pVideoState->get_stream_time();
-}
-
-double FfmpegAvPlayback::get_fps() const { return pVideoState->get_fps(); }
-
-int FfmpegAvPlayback::set_rate(double rate) {
-  int err = pVideoState->set_rate(rate);
+int FfmpegAvPlayback::SetSpeed(double speed) {
+  int err = p_video_state_->SetSpeed(speed);
   return err ? ERROR_FFMPEG_FILTER_NOT_FOUND : ERROR_NONE;
 }
 
-double FfmpegAvPlayback::get_rate() const { return pVideoState->get_rate(); }
-
-int64_t FfmpegAvPlayback::get_start_time() const {
-  return pVideoState->get_ic()->start_time;
-}
-
-int64_t FfmpegAvPlayback::get_seek_pos() const {
-  return pVideoState->get_seek_pos();
-}
-
-int FfmpegAvPlayback::get_frame_timer() { return frame_timer; }
-
-void FfmpegAvPlayback::set_frame_timer(int new_frame_timer) {
-  frame_timer = new_frame_timer;
-}
-
-void FfmpegAvPlayback::set_force_refresh(int refresh) {
-  force_refresh = refresh;
-}
-
-double FfmpegAvPlayback::vp_duration(Frame *vp, Frame *nextvp,
-                                     double max_frame_duration) {
+double FfmpegAvPlayback::ComputeFrameDuration(Frame *vp, Frame *nextvp,
+                                              double max_frame_duration) {
   if (vp->serial == nextvp->serial) {
-    double duration = (nextvp->pts - vp->pts) / pVideoState->get_rate();
+    double duration = (nextvp->pts - vp->pts) / p_video_state_->GetSpeed();
     if (isnan(duration) || duration <= 0 || duration > max_frame_duration)
       return vp->duration;
     else
@@ -122,12 +79,4 @@ double FfmpegAvPlayback::vp_duration(Frame *vp, Frame *nextvp,
   } else {
     return 0.0;
   }
-}
-
-void FfmpegAvPlayback::step_to_next_frame() {
-  /* if the stream is paused unpause it, then step */
-  if (pVideoState->get_paused())
-    stream_toggle_pause();
-
-  pVideoState->set_step(true);
 }

--- a/src/main/cpp/FfmpegAvPlayback.h
+++ b/src/main/cpp/FfmpegAvPlayback.h
@@ -4,45 +4,75 @@
 #include "VideoState.h"
 
 class FfmpegAvPlayback {
-protected:
-  VideoState *pVideoState;
-  double frame_timer;
-
-  int width, height;
-
-  int force_refresh;
-  int display_disable;
-
-  int frame_drops_late;
-  double rdftspeed;
-  double last_vis_time;
-
-  void stream_toggle_pause();
-  int get_frame_timer();
-  void set_frame_timer(int newFrame_timer);
-  void set_force_refresh(int refresh);
-  double vp_duration(Frame *vp, Frame *nextvp, double max_frame_duration);
-  static bool kEnableShowStatus;
-
 public:
   FfmpegAvPlayback();
-  int Init(const char *filename, AVInputFormat *iformat, int audio_buffer_size);
-  virtual ~FfmpegAvPlayback();
+  int OpenVideo(const char *filename, AVInputFormat *iformat,
+                int audio_buffer_size);
   virtual void
-  set_player_state_callback_func(VideoState::PlayerStateCallback callback,
+  SetPlayerStateCallbackFunction(VideoState::PlayerStateCallback callback,
                                  const std::function<void()> &func);
-  virtual void play();
-  virtual void stop();
-  virtual void toggle_pause();
-  virtual void stream_seek(int64_t pos, int64_t rel, int seek_by_bytes);
-  virtual double get_duration() const;
-  virtual double get_stream_time() const;
-  virtual double get_fps() const;
-  virtual int set_rate(double rate);
-  virtual double get_rate() const;
-  int64_t get_start_time() const;
-  int64_t get_seek_pos() const;
-  void step_to_next_frame();
+  virtual void Play();
+  virtual void Stop();
+  virtual void TogglePauseAndStopStep();
+
+  inline virtual void Seek(int64_t pos, int64_t rel, int seek_by_bytes) {
+    p_video_state_->stream_seek(pos, rel, seek_by_bytes);
+  }
+  inline virtual double GetDuration() const {
+    return p_video_state_->get_duration();
+  }
+  inline virtual double GetTime() const {
+    return p_video_state_->get_stream_time();
+  }
+  inline virtual double GetFrameRate() const {
+    return p_video_state_->GetFrameRate();
+  }
+
+  // Set the playback speed
+  virtual int SetSpeed(double speed);
+
+  // Get the playback speed
+  inline virtual double GetSpeed() const { return p_video_state_->GetSpeed(); }
+
+  inline int64_t GetStartTime() const { return p_video_state_->get_ic()->start_time; }
+  inline int64_t GetSeekTime() const { return p_video_state_->get_seek_pos(); }
+  inline void StepToNextFrame() {
+    /* if the stream is paused unpause it, then step */
+    if (p_video_state_->get_paused())
+      TogglePause();
+
+    p_video_state_->SetStepping(true);
+  }
+
+protected:
+  // The video state used for this playback
+  VideoState *p_video_state_;
+  // Time when the last frame was shown
+  double frame_last_shown_time_;
+
+  int frame_width_;
+  int frame_height_;
+
+  // Force a refresh of the display
+  bool force_refresh_;
+
+  // Disable the display
+  bool display_disabled_;
+
+  // Counts the number of early frame drops
+  int num_frame_drops_late_;
+
+  // Enable the showing of the status
+  static bool kEnableShowStatus;
+
+  void TogglePause();
+  inline double GetFrameLastShownTime() const { return frame_last_shown_time_; }
+  inline void SetFrameLastShownTime(double time) {
+    frame_last_shown_time_ = time;
+  }
+  inline void set_force_refresh(bool refresh) { force_refresh_ = refresh; }
+  double ComputeFrameDuration(Frame *vp, Frame *nextvp,
+                              double max_frame_duration);
 };
 
 #endif // FFMPEGAVPLAYBACK_H_

--- a/src/main/cpp/FfmpegErrorUtils.cpp
+++ b/src/main/cpp/FfmpegErrorUtils.cpp
@@ -15,7 +15,7 @@ extern "C" {
 #include "libavutil/error.h"
 }
 
-int ffmpegToJavaErrNo(int ffmpegErrNo) {
+int FfmpegToJavaErrNo(int ffmpegErrNo) {
   int err = AVERROR(EINVAL);
   if (ffmpegErrNo == err) {
     std::cout << "EINVAL error" << std::endl;

--- a/src/main/cpp/FfmpegErrorUtils.h
+++ b/src/main/cpp/FfmpegErrorUtils.h
@@ -1,6 +1,6 @@
 #ifndef _FFMPEG_ERROR_UTILS_H_
 #define _FFMPEG_ERROR_UTILS_H_
 
-int ffmpegToJavaErrNo(int ffmpegErrNo);
+int FfmpegToJavaErrNo(int ffmpegErrNo);
 
 #endif // _FFMPEG_ERROR_UTILS_H_

--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -5,9 +5,9 @@
 FfmpegJavaAvPlayback::FfmpegJavaAvPlayback(const AudioFormat *pAudioFormat,
                                            const PixelFormat *pPixelFormat,
                                            const int audioBufferSizeInBy)
-    : FfmpegAvPlayback(), pAudioFormat(pAudioFormat),
-      pPixelFormat(pPixelFormat), audioBufferSizeInBy(audioBufferSizeInBy),
-      img_convert_ctx(nullptr), remaining_time_to_display(0) {}
+    : FfmpegAvPlayback(), kPtrAudioFormat(pAudioFormat),
+      kPtrPixelFormat(pPixelFormat), kAudioBufferSizeInBy(audioBufferSizeInBy),
+      img_convert_ctx_(nullptr), remaining_time_to_display_(0) {}
 
 FfmpegJavaAvPlayback::~FfmpegJavaAvPlayback() {}
 
@@ -19,152 +19,152 @@ int FfmpegJavaAvPlayback::Init(const char *filename, AVInputFormat *iformat) {
 #endif
   avformat_network_init();
 
-  int err = FfmpegAvPlayback::Init(
-      filename, iformat, audioBufferSizeInBy); // initializes the video state
+  int err = FfmpegAvPlayback::OpenVideo(
+      filename, iformat, kAudioBufferSizeInBy); // initializes the video state
   if (err) {
     return err;
   }
 
-  pVideoState->set_destroy_callback([this] { destroy(); });
+  p_video_state_->SetDestroyCallback([this] { Destroy(); });
 
   // TODO: Clean-up this callback as the first three parameters are not used
   // here
-  pVideoState->set_audio_open_callback(
+  p_video_state_->SetAudioOpenCallback(
       [this](int64_t wanted_channel_layout, int wanted_nb_channels,
              int wanted_sample_rate, struct AudioParams *audio_hw_params) {
-        return audio_open(wanted_channel_layout, wanted_nb_channels,
+        return AudioOpen(wanted_channel_layout, wanted_nb_channels,
                           wanted_sample_rate, audio_hw_params);
       });
 
-  pVideoState->set_step_to_next_frame_callback(
-      [this] { this->step_to_next_frame(); });
+  p_video_state_->SetStepToNextFrameCallback(
+      [this] { this->StepToNextFrame(); });
 
   return ERROR_NONE;
 }
 
-VideoState *FfmpegJavaAvPlayback::get_VideoState() { return pVideoState; }
+VideoState *FfmpegJavaAvPlayback::GetVideoState() { return p_video_state_; }
 
-int FfmpegJavaAvPlayback::audio_open(int64_t wanted_channel_layout,
+int FfmpegJavaAvPlayback::AudioOpen(int64_t wanted_channel_layout,
                                      int wanted_nb_channels,
                                      int wanted_sample_rate,
                                      struct AudioParams *audio_hw_params) {
   // TODO(fraudies): If we need to change the audio format overwrite
   // pAudioFormat here
-  pAudioFormat->toAudioParams(audio_hw_params);
-  return audioBufferSizeInBy;
+  kPtrAudioFormat->toAudioParams(audio_hw_params);
+  return kAudioBufferSizeInBy;
 }
 
-void FfmpegJavaAvPlayback::destroy() {
+void FfmpegJavaAvPlayback::Destroy() {
 
-  sws_freeContext(img_convert_ctx);
+  sws_freeContext(img_convert_ctx_);
 
-  delete pVideoState;
+  delete p_video_state_;
   avformat_network_deinit();
 
   av_log(NULL, AV_LOG_QUIET, "%s", "");
 }
 
-int FfmpegJavaAvPlayback::start_stream() {
-  return ffmpegToJavaErrNo(pVideoState->stream_start());
+int FfmpegJavaAvPlayback::StartStream() {
+  return ffmpegToJavaErrNo(p_video_state_->StartStream());
 }
 
-void FfmpegJavaAvPlayback::set_balance(float fBalance) {}
+void FfmpegJavaAvPlayback::SetBalance(float fBalance) {}
 
-float FfmpegJavaAvPlayback::get_balance() { return 0.0f; }
+float FfmpegJavaAvPlayback::GetBalance() { return 0.0f; }
 
-void FfmpegJavaAvPlayback::set_audioSyncDelay(long lMillis) {}
+void FfmpegJavaAvPlayback::SetAudioSyncDelay(long lMillis) {}
 
-long FfmpegJavaAvPlayback::get_audioSyncDelay() { return 0; }
+long FfmpegJavaAvPlayback::getAudioSyncDelay() { return 0; }
 
-int FfmpegJavaAvPlayback::get_image_width() const {
-  return pVideoState->get_image_width();
+int FfmpegJavaAvPlayback::GetImageWidth() const {
+  return p_video_state_->GetFrameWidth();
 }
 
-int FfmpegJavaAvPlayback::get_image_height() const {
-  return pVideoState->get_image_height();
+int FfmpegJavaAvPlayback::GetImageHeight() const {
+  return p_video_state_->GetFrameHeight();
 }
 
-bool FfmpegJavaAvPlayback::has_image_data() const {
-  return pVideoState->has_image_data();
+bool FfmpegJavaAvPlayback::HasImageData() const {
+  return p_video_state_->has_image_data();
 }
 
-bool FfmpegJavaAvPlayback::has_audio_data() const {
-  return pVideoState->has_audio_data();
+bool FfmpegJavaAvPlayback::HasAudioData() const {
+  return p_video_state_->has_audio_data();
 }
 
-bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
+bool FfmpegJavaAvPlayback::DoDisplay(double *remaining_time) {
   bool display = false;
 
   double time;
 
   Frame *sp, *sp2;
 
-  if (pVideoState->get_video_st()) {
+  if (p_video_state_->get_video_st()) {
   retry:
-    if (pVideoState->get_pPictq()->nb_remaining() == 0) {
+    if (p_video_state_->get_pPictq()->nb_remaining() == 0) {
       // nothing to do, no picture to display in the queue
     } else {
       double last_duration, duration, delay;
       Frame *vp, *lastvp;
 
       /* dequeue the picture */
-      lastvp = pVideoState->get_pPictq()->peek_last();
-      vp = pVideoState->get_pPictq()->peek();
+      lastvp = p_video_state_->get_pPictq()->peek_last();
+      vp = p_video_state_->get_pPictq()->peek();
 
-      if (vp->serial != pVideoState->get_pVideoq()->get_serial()) {
-        pVideoState->get_pPictq()->next();
+      if (vp->serial != p_video_state_->get_pVideoq()->get_serial()) {
+        p_video_state_->get_pPictq()->next();
         goto retry;
       }
 
       if (lastvp->serial != vp->serial)
-        frame_timer = av_gettime_relative() / 1000000.0;
+        frame_last_shown_time_ = av_gettime_relative() / 1000000.0;
 
-      if (pVideoState->get_paused() && !force_refresh)
+      if (p_video_state_->get_paused() && !force_refresh_)
         goto display;
 
       /* compute nominal last_duration */
       last_duration =
-          vp_duration(lastvp, vp, pVideoState->get_max_frame_duration());
-      delay = pVideoState->compute_target_delay(last_duration);
+          ComputeFrameDuration(lastvp, vp, p_video_state_->get_max_frame_duration());
+      delay = p_video_state_->compute_target_delay(last_duration);
 
       time = av_gettime_relative() / 1000000.0;
-      if (time < frame_timer + delay) {
-        *remaining_time = FFMIN(frame_timer + delay - time, *remaining_time);
+      if (time < frame_last_shown_time_ + delay) {
+        *remaining_time = FFMIN(frame_last_shown_time_ + delay - time, *remaining_time);
         goto display;
       }
 
-      frame_timer += delay;
-      if (delay > 0 && time - frame_timer > VideoState::kAvSyncThresholdMax)
-        frame_timer = time;
+      frame_last_shown_time_ += delay;
+      if (delay > 0 && time - frame_last_shown_time_ > VideoState::kAvSyncThresholdMax)
+        frame_last_shown_time_ = time;
 
       std::unique_lock<std::mutex> locker(
-          pVideoState->get_pPictq()->get_mutex());
+          p_video_state_->get_pPictq()->get_mutex());
       if (!isnan(vp->pts))
-        pVideoState->update_pts(vp->pts, vp->serial);
+        p_video_state_->update_pts(vp->pts, vp->serial);
       locker.unlock();
 
-      if (pVideoState->get_pPictq()->nb_remaining() > 1) {
-        Frame *nextvp = pVideoState->get_pPictq()->peek_next();
+      if (p_video_state_->get_pPictq()->nb_remaining() > 1) {
+        Frame *nextvp = p_video_state_->get_pPictq()->peek_next();
         duration =
-            vp_duration(vp, nextvp, pVideoState->get_max_frame_duration());
-        if (!pVideoState->get_step() && time > frame_timer + duration) {
-          frame_drops_late++;
-          pVideoState->get_pPictq()->next();
+            ComputeFrameDuration(vp, nextvp, p_video_state_->get_max_frame_duration());
+        if (!p_video_state_->IsStepping() && time > frame_last_shown_time_ + duration) {
+          num_frame_drops_late_++;
+          p_video_state_->get_pPictq()->next();
           goto retry;
         }
       }
 
-      pVideoState->get_pPictq()->next();
-      force_refresh = 1;
+      p_video_state_->get_pPictq()->next();
+      force_refresh_ = true;
     }
   display:
     /* display picture */
-    if (!display_disable && force_refresh &&
-        pVideoState->get_pPictq()->get_rindex_shown()) {
+    if (!display_disabled_ && force_refresh_ &&
+        p_video_state_->get_pPictq()->get_rindex_shown()) {
       display = true;
-      force_refresh = 0;
-      if (pVideoState->get_step() && !pVideoState->get_paused())
-        stream_toggle_pause();
+      force_refresh_ = false;
+      if (p_video_state_->IsStepping() && !p_video_state_->get_paused())
+        TogglePause();
     }
   }
 
@@ -179,43 +179,43 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
       aqsize = 0;
       vqsize = 0;
       sqsize = 0;
-      if (pVideoState->get_audio_st())
-        aqsize = pVideoState->get_pAudioq()->get_size();
-      if (pVideoState->get_video_st())
-        vqsize = pVideoState->get_pVideoq()->get_size();
+      if (p_video_state_->get_audio_st())
+        aqsize = p_video_state_->get_pAudioq()->get_size();
+      if (p_video_state_->get_video_st())
+        vqsize = p_video_state_->get_pVideoq()->get_size();
       av_diff = 0;
-      if (pVideoState->get_audio_st() && pVideoState->get_video_st())
-        av_diff = pVideoState->get_pAudclk()->get_time() -
-                  pVideoState->get_pVidclk()->get_time();
-      else if (pVideoState->get_video_st())
-        av_diff = pVideoState->get_master_clock()->get_time() -
-                  pVideoState->get_pVidclk()->get_time();
-      else if (pVideoState->get_audio_st())
-        av_diff = pVideoState->get_master_clock()->get_time() -
-                  pVideoState->get_pAudclk()->get_time();
+      if (p_video_state_->get_audio_st() && p_video_state_->get_video_st())
+        av_diff = p_video_state_->get_pAudclk()->get_time() -
+                  p_video_state_->get_pVidclk()->get_time();
+      else if (p_video_state_->get_video_st())
+        av_diff = p_video_state_->get_master_clock()->get_time() -
+                  p_video_state_->get_pVidclk()->get_time();
+      else if (p_video_state_->get_audio_st())
+        av_diff = p_video_state_->get_master_clock()->get_time() -
+                  p_video_state_->get_pAudclk()->get_time();
       av_log(NULL, AV_LOG_INFO,
              "m %7.2f, a %7.2f, v %7.2f at %1.3fX %s:%7.3f de=%4d dl=%4d "
              "re=%7.2f aq=%5dKB vq=%5dKB sq=%5dB f=%f /%f   \r",
-             pVideoState->get_master_clock()->get_time(),
-             pVideoState->get_pAudclk() != nullptr
-                 ? pVideoState->get_pAudclk()->get_time()
+             p_video_state_->get_master_clock()->get_time(),
+             p_video_state_->get_pAudclk() != nullptr
+                 ? p_video_state_->get_pAudclk()->get_time()
                  : 0,
-             pVideoState->get_pVidclk() != nullptr
-                 ? pVideoState->get_pVidclk()->get_time()
+             p_video_state_->get_pVidclk() != nullptr
+                 ? p_video_state_->get_pVidclk()->get_time()
                  : 0,
-             pVideoState->get_rate(),
-             (pVideoState->get_audio_st() && pVideoState->get_video_st())
+             p_video_state_->GetSpeed(),
+             (p_video_state_->get_audio_st() && p_video_state_->get_video_st())
                  ? "A-V"
-                 : (pVideoState->get_video_st()
+                 : (p_video_state_->get_video_st()
                         ? "M-V"
-                        : (pVideoState->get_audio_st() ? "M-A" : "   ")),
-             av_diff, pVideoState->get_frame_drops_early(), frame_drops_late,
+                        : (p_video_state_->get_audio_st() ? "M-A" : "   ")),
+             av_diff, p_video_state_->get_frame_drops_early(), num_frame_drops_late_,
              *remaining_time, aqsize / 1024, vqsize / 1024, sqsize,
-             pVideoState->get_video_st() ? pVideoState->get_pViddec()
+             p_video_state_->get_video_st() ? p_video_state_->get_pViddec()
                                                ->get_avctx()
                                                ->pts_correction_num_faulty_dts
                                          : 0,
-             pVideoState->get_video_st() ? pVideoState->get_pViddec()
+             p_video_state_->get_video_st() ? p_video_state_->get_pViddec()
                                                ->get_avctx()
                                                ->pts_correction_num_faulty_pts
                                          : 0);
@@ -227,23 +227,23 @@ bool FfmpegJavaAvPlayback::do_display(double *remaining_time) {
   return display;
 }
 
-void FfmpegJavaAvPlayback::update_image_buffer(uint8_t *pImageData,
+void FfmpegJavaAvPlayback::UpdateImageBuffer(uint8_t *pImageData,
                                                const long len) {
-  bool doUpdate = do_display(&remaining_time_to_display);
+  bool doUpdate = DoDisplay(&remaining_time_to_display_);
   if (doUpdate) {
-    Frame *vp = pVideoState->get_pPictq()->peek_last();
-    img_convert_ctx = sws_getCachedContext(
-        img_convert_ctx, vp->frame->width, vp->frame->height,
+    Frame *vp = p_video_state_->get_pPictq()->peek_last();
+    img_convert_ctx_ = sws_getCachedContext(
+        img_convert_ctx_, vp->frame->width, vp->frame->height,
         static_cast<AVPixelFormat>(vp->frame->format), vp->frame->width,
-        vp->frame->height, pPixelFormat->type, SWS_BICUBIC, NULL, NULL, NULL);
-    if (img_convert_ctx != NULL) {
+        vp->frame->height, kPtrPixelFormat->type, SWS_BICUBIC, NULL, NULL, NULL);
+    if (img_convert_ctx_ != NULL) {
       // TODO(fraudies): Add switch case statement for the different pixel
       // formats Left the pixels allocation/free here to support resizing
       // through sws_scale natively
       uint8_t *pixels[4];
       int pitch[4];
       av_image_alloc(pixels, pitch, vp->width, vp->height, AV_PIX_FMT_RGB24, 1);
-      sws_scale(img_convert_ctx, (const uint8_t *const *)vp->frame->data,
+      sws_scale(img_convert_ctx_, (const uint8_t *const *)vp->frame->data,
                 vp->frame->linesize, 0, vp->frame->height, pixels, pitch);
       // Maybe check that we have 3 components
       memcpy(pImageData, pixels[0],
@@ -253,15 +253,15 @@ void FfmpegJavaAvPlayback::update_image_buffer(uint8_t *pImageData,
   }
 }
 
-void FfmpegJavaAvPlayback::update_audio_buffer(uint8_t *pAudioData,
+void FfmpegJavaAvPlayback::UpdateAudioBuffer(uint8_t *pAudioData,
                                                const long len) {
-  pVideoState->audio_callback(pAudioData, len);
+  p_video_state_->audio_callback(pAudioData, len);
 }
 
-void FfmpegJavaAvPlayback::get_audio_format(AudioFormat *pAudioFormat) {
-  *pAudioFormat = *this->pAudioFormat;
+void FfmpegJavaAvPlayback::GetAudioFormat(AudioFormat *pAudioFormat) {
+  *pAudioFormat = *this->kPtrAudioFormat;
 }
 
-void FfmpegJavaAvPlayback::get_pixel_format(PixelFormat *pPixelFormat) {
-  *pPixelFormat = *this->pPixelFormat;
+void FfmpegJavaAvPlayback::GetPixelFormat(PixelFormat *pPixelFormat) {
+  *pPixelFormat = *this->kPtrPixelFormat;
 }

--- a/src/main/cpp/FfmpegJavaAvPlayback.h
+++ b/src/main/cpp/FfmpegJavaAvPlayback.h
@@ -10,7 +10,7 @@ private:
   const PixelFormat *kPtrPixelFormat;
   const int kAudioBufferSizeInBy;
 
-  struct SwsContext *img_convert_ctx_;
+  struct SwsContext *p_img_convert_ctx_;
   double remaining_time_to_display_;
 
 public:
@@ -19,7 +19,7 @@ public:
                        const int kAudioBufferSizeInBy);
   virtual ~FfmpegJavaAvPlayback();
 
-  int Init(const char *filename, AVInputFormat *iformat);
+  int Init(const char *p_filename, AVInputFormat *p_input_format);
 
   int AudioOpen(int64_t wanted_channel_layout, int wanted_nb_channels,
                 int wanted_sample_rate, struct AudioParams *audio_hw_params);
@@ -30,10 +30,10 @@ public:
 
   int StartStream();
 
-  void SetBalance(float fBalance);
+  void SetBalance(float balance);
   float GetBalance();
 
-  void SetAudioSyncDelay(long lMillis);
+  void SetAudioSyncDelay(long millis);
   long getAudioSyncDelay();
 
   int GetImageWidth() const;
@@ -42,13 +42,13 @@ public:
   bool HasImageData() const;
   bool HasAudioData() const;
 
-  bool DoDisplay(double *remaining_time);
+  bool DoDisplay(double *p_remaining_time);
 
-  void UpdateImageBuffer(uint8_t *pImageData, const long len);
-  void UpdateAudioBuffer(uint8_t *pAudioData, const long len);
+  void UpdateImageBuffer(uint8_t *p_image_data, const long len);
+  void UpdateAudioBuffer(uint8_t *p_audio_data, const long len);
 
-  void GetAudioFormat(AudioFormat *pAudioFormat);
-  void GetPixelFormat(PixelFormat *pPixelFormat);
+  void GetAudioFormat(AudioFormat *p_audio_format);
+  void GetPixelFormat(PixelFormat *p_pixel_format);
 };
 
 #endif // end of FFMPEGJAVAAVPLAYBACK_H_

--- a/src/main/cpp/FfmpegJavaAvPlayback.h
+++ b/src/main/cpp/FfmpegJavaAvPlayback.h
@@ -6,48 +6,49 @@
 
 class FfmpegJavaAvPlayback : public FfmpegAvPlayback {
 private:
-  const AudioFormat *pAudioFormat;
-  const PixelFormat *pPixelFormat;
-  const int audioBufferSizeInBy;
-  struct SwsContext *img_convert_ctx;
-  double remaining_time_to_display;
+  const AudioFormat *kPtrAudioFormat;
+  const PixelFormat *kPtrPixelFormat;
+  const int kAudioBufferSizeInBy;
+
+  struct SwsContext *img_convert_ctx_;
+  double remaining_time_to_display_;
 
 public:
-  FfmpegJavaAvPlayback(const AudioFormat *pAudioFormat,
-                       const PixelFormat *pPixelFormat,
-                       const int audioBufferSizeInBy);
+  FfmpegJavaAvPlayback(const AudioFormat *kPtrAudioFormat,
+                       const PixelFormat *kPtrPixelFormat,
+                       const int kAudioBufferSizeInBy);
   virtual ~FfmpegJavaAvPlayback();
 
   int Init(const char *filename, AVInputFormat *iformat);
 
-  int audio_open(int64_t wanted_channel_layout, int wanted_nb_channels,
-                 int wanted_sample_rate, struct AudioParams *audio_hw_params);
+  int AudioOpen(int64_t wanted_channel_layout, int wanted_nb_channels,
+                int wanted_sample_rate, struct AudioParams *audio_hw_params);
 
-  VideoState *get_VideoState();
+  VideoState *GetVideoState();
 
-  void destroy();
+  void Destroy();
 
-  int start_stream();
+  int StartStream();
 
-  void set_balance(float fBalance);
-  float get_balance();
+  void SetBalance(float fBalance);
+  float GetBalance();
 
-  void set_audioSyncDelay(long lMillis);
-  long get_audioSyncDelay();
+  void SetAudioSyncDelay(long lMillis);
+  long getAudioSyncDelay();
 
-  int get_image_width() const;
-  int get_image_height() const;
+  int GetImageWidth() const;
+  int GetImageHeight() const;
 
-  bool has_image_data() const;
-  bool has_audio_data() const;
+  bool HasImageData() const;
+  bool HasAudioData() const;
 
-  bool do_display(double *remaining_time);
+  bool DoDisplay(double *remaining_time);
 
-  void update_image_buffer(uint8_t *pImageData, const long len);
-  void update_audio_buffer(uint8_t *pAudioData, const long len);
+  void UpdateImageBuffer(uint8_t *pImageData, const long len);
+  void UpdateAudioBuffer(uint8_t *pAudioData, const long len);
 
-  void get_audio_format(AudioFormat *pAudioFormat);
-  void get_pixel_format(PixelFormat *pPixelFormat);
+  void GetAudioFormat(AudioFormat *pAudioFormat);
+  void GetPixelFormat(PixelFormat *pPixelFormat);
 };
 
 #endif // end of FFMPEGJAVAAVPLAYBACK_H_

--- a/src/main/cpp/FfmpegJavaAvPlaybackPipline.h
+++ b/src/main/cpp/FfmpegJavaAvPlaybackPipline.h
@@ -9,7 +9,7 @@ class FfmpegJavaAvPlaybackPipline : public CPipelineData {
 public:
   virtual uint32_t Init(const char *input_file);
   virtual void Dispose();
-  FfmpegJavaAvPlaybackPipline(CPipelineOptions *pOptions);
+  FfmpegJavaAvPlaybackPipline(CPipelineOptions *p_options);
   virtual ~FfmpegJavaAvPlaybackPipline();
 
 private:
@@ -20,35 +20,35 @@ private:
   virtual uint32_t StepBackward();
   virtual uint32_t Finish();
 
-  virtual uint32_t Seek(double dSeekTime);
+  virtual uint32_t Seek(double seek_time);
 
-  virtual uint32_t GetDuration(double *pdDuration);
-  virtual uint32_t GetStreamTime(double *pdStreamTime);
-  virtual uint32_t GetFps(double *pdFps);
+  virtual uint32_t GetDuration(double *p_duration);
+  virtual uint32_t GetStreamTime(double *p_stream_time);
+  virtual uint32_t GetFps(double *p_fps);
 
-  virtual uint32_t SetRate(float fRate);
-  virtual uint32_t GetRate(float *pfRate);
+  virtual uint32_t SetRate(float rate);
+  virtual uint32_t GetRate(float *p_rate);
 
-  virtual uint32_t SetVolume(float fVolume);
-  virtual uint32_t GetVolume(float *pfVolume);
+  virtual uint32_t SetVolume(float volume);
+  virtual uint32_t GetVolume(float *p_volume);
 
-  virtual uint32_t SetBalance(float fBalance);
-  virtual uint32_t GetBalance(float *pfBalance);
+  virtual uint32_t SetBalance(float balance);
+  virtual uint32_t GetBalance(float *p_balance);
 
-  virtual uint32_t SetAudioSyncDelay(long lMillis);
-  virtual uint32_t GetAudioSyncDelay(long *plMillis);
+  virtual uint32_t SetAudioSyncDelay(long millis);
+  virtual uint32_t GetAudioSyncDelay(long *p_millis);
 
   // Fullfill the data interface
-  virtual uint32_t HasAudioData(bool *bAudioData) const;
-  virtual uint32_t HasImageData(bool *bImageData) const;
-  virtual uint32_t GetImageWidth(int *iWidth) const;
-  virtual uint32_t GetImageHeight(int *iHeight) const;
-  virtual uint32_t GetAudioFormat(AudioFormat *pAudioParams) const;
-  virtual uint32_t GetPixelFormat(PixelFormat *pPixelFormat) const;
-  virtual uint32_t UpdateImageBuffer(uint8_t *pImageData, const long len);
-  virtual uint32_t UpdateAudioBuffer(uint8_t *pAudioData, const long len);
+  virtual uint32_t HasAudioData(bool *p_audio_data) const;
+  virtual uint32_t HasImageData(bool *p_image_data) const;
+  virtual uint32_t GetImageWidth(int *p_width) const;
+  virtual uint32_t GetImageHeight(int *p_height) const;
+  virtual uint32_t GetAudioFormat(AudioFormat *p_audio_params) const;
+  virtual uint32_t GetPixelFormat(PixelFormat *p_pixel_format) const;
+  virtual uint32_t UpdateImageBuffer(uint8_t *p_image_data, const long len);
+  virtual uint32_t UpdateAudioBuffer(uint8_t *p_audio_data, const long len);
 
-  FfmpegJavaAvPlayback *pJavaPlayback;
+  FfmpegJavaAvPlayback *p_java_playback_;
 };
 
 #endif // !FFMPEGJAVAAVPLAYBACKPIPELINE_H_

--- a/src/main/cpp/FfmpegJavaMediaPlayer.vcxproj
+++ b/src/main/cpp/FfmpegJavaMediaPlayer.vcxproj
@@ -87,6 +87,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>C:\Program Files\Java\jdk1.8.0_172\include\win32;C:\Program Files\Java\jdk1.8.0_172\include;C:\FFplay64\include;$(IncludePath)</IncludePath>
     <LibraryPath>C:\Program Files\Java\jdk1.8.0_172\lib;C:\FFplay64\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -94,7 +96,6 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>jawt.lib;avutil.lib;avdevice.lib;avfilter.lib;avformat.lib;avcodec.lib;postproc.lib;swresample.lib;swscale.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/main/cpp/FfmpegJavaMediaPlayer.vcxproj.filters
+++ b/src/main/cpp/FfmpegJavaMediaPlayer.vcxproj.filters
@@ -33,9 +33,6 @@
     <ClInclude Include="PipelineData.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="FfmpegErrorUtils.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FfmpegJavaAvPlayback.cpp">
@@ -48,9 +45,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="PipelineData.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FfmpegErrorUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/main/cpp/FfmpegJniUtils.cpp
+++ b/src/main/cpp/FfmpegJniUtils.cpp
@@ -1,238 +1,241 @@
 #include "FfmpegJniUtils.h"
 #include "MediaPlayerErrors.h"
 
-uint32_t SetJAudioFormat(JNIEnv *env, jobject jAudioFormat,
-                         const AudioFormat &audioFormat) {
+uint32_t SetJAudioFormat(JNIEnv *env, jobject j_audio_format,
+                         const AudioFormat &audio_format) {
 
   // Get the audio format class
-  jclass audioFormatClass = env->GetObjectClass(jAudioFormat);
-  if (audioFormatClass == nullptr) {
+  jclass audio_format_class = env->GetObjectClass(j_audio_format);
+  if (audio_format_class == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_NULL;
   }
 
   // Set the audio encoding (nested class)
-  jfieldID encodingId =
-      env->GetFieldID(audioFormatClass, "encoding",
+  jfieldID encoding_id =
+      env->GetFieldID(audio_format_class, "encoding",
                       "Ljavax/sound/sampled/AudioFormat$Encoding;");
-  if (encodingId == nullptr) {
+  if (encoding_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_ID_NULL;
   }
-  jobject jEncoding = env->GetObjectField(jAudioFormat, encodingId);
-  if (jEncoding == nullptr) {
+  jobject j_encoding = env->GetObjectField(j_audio_format, encoding_id);
+  if (j_encoding == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_NULL;
   }
-  jclass encodingClass = env->GetObjectClass(jEncoding);
-  if (encodingClass == nullptr) {
+  jclass encoding_class = env->GetObjectClass(j_encoding);
+  if (encoding_class == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_CLASS_NULL;
   }
-  jfieldID encodingNameId =
-      env->GetFieldID(encodingClass, "name", "Ljava/lang/String;");
-  if (encodingNameId == nullptr) {
+  jfieldID encoding_name_id =
+      env->GetFieldID(encoding_class, "name", "Ljava/lang/String;");
+  if (encoding_name_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_NAME_ID_NULL;
   }
-  env->SetObjectField(jEncoding, encodingNameId,
-                      env->NewStringUTF(audioFormat.encoding.c_str()));
+  env->SetObjectField(j_encoding, encoding_name_id,
+                      env->NewStringUTF(audio_format.encoding_name_.c_str()));
 
   // Set endianess
-  jfieldID bigEndianId = env->GetFieldID(audioFormatClass, "bigEndian", "Z");
-  if (bigEndianId == nullptr) {
+  jfieldID big_endian_id = env->GetFieldID(audio_format_class, "bigEndian", "Z");
+  if (big_endian_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENDIAN_ID_NULL;
   }
-  env->SetBooleanField(jAudioFormat, bigEndianId,
-                       (jboolean)audioFormat.bigEndian);
+  env->SetBooleanField(j_audio_format, big_endian_id,
+                       (jboolean)audio_format.is_big_endian_);
 
   // Set sample rate
-  jfieldID sampleRateId = env->GetFieldID(audioFormatClass, "sampleRate", "F");
-  if (sampleRateId == nullptr) {
+  jfieldID sample_rate_id =
+      env->GetFieldID(audio_format_class, "sampleRate", "F");
+  if (sample_rate_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_SAMPLE_RATE_ID_NULL;
   }
-  env->SetFloatField(jAudioFormat, sampleRateId,
-                     (jfloat)audioFormat.sampleRate);
+  env->SetFloatField(j_audio_format, sample_rate_id,
+                     (jfloat)audio_format.sample_rate_);
 
   // Set sample size in bits
-  jfieldID sampleSizeInBitsId =
-      env->GetFieldID(audioFormatClass, "sampleSizeInBits", "I");
-  if (sampleSizeInBitsId == nullptr) {
+  jfieldID sample_size_in_bits_id =
+      env->GetFieldID(audio_format_class, "sampleSizeInBits", "I");
+  if (sample_size_in_bits_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_SAMPLE_SIZE_IN_BITS_ID_NULL;
   }
-  env->SetIntField(jAudioFormat, sampleSizeInBitsId,
-                   (jint)(audioFormat.sampleSizeInBits));
+  env->SetIntField(j_audio_format, sample_size_in_bits_id,
+                   (jint)(audio_format.sample_size_in_bits_));
 
   // Set the number of channels
-  jfieldID channelsId = env->GetFieldID(audioFormatClass, "channels", "I");
-  if (channelsId == nullptr) {
+  jfieldID channels_id = env->GetFieldID(audio_format_class, "channels", "I");
+  if (channels_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_CHANNELS_ID_NULL;
   }
-  env->SetIntField(jAudioFormat, channelsId, (jint)audioFormat.channels);
+  env->SetIntField(j_audio_format, channels_id,
+                   (jint)audio_format.num_channels_);
 
   // Set the frame size in bytes
-  jfieldID frameSizeId = env->GetFieldID(audioFormatClass, "frameSize", "I");
-  if (frameSizeId == nullptr) {
+  jfieldID frame_size_id = env->GetFieldID(audio_format_class, "frameSize", "I");
+  if (frame_size_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_FRAME_SIZE_ID_NULL;
   }
-  env->SetIntField(jAudioFormat, frameSizeId, (jint)audioFormat.frameSize);
+  env->SetIntField(j_audio_format, frame_size_id, (jint)audio_format.frame_size_);
 
   // Set the frame rate in Hertz
-  jfieldID frameRateId = env->GetFieldID(audioFormatClass, "frameRate", "F");
-  if (frameRateId == nullptr) {
+  jfieldID frame_rate_id = env->GetFieldID(audio_format_class, "frameRate", "F");
+  if (frame_rate_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_FRAME_RATE_ID_NULL;
   }
-  env->SetFloatField(jAudioFormat, frameRateId, (jfloat)audioFormat.frameRate);
+  env->SetFloatField(j_audio_format, frame_rate_id,
+                     (jfloat)audio_format.frame_rate_);
 
   return ERROR_NONE;
 }
 
-uint32_t SetJPixelFormat(JNIEnv *env, jobject jColorSpace,
+uint32_t SetJPixelFormat(JNIEnv *env, jobject j_color_space,
                          const PixelFormat &pixelFormat) {
 
   // Get the audio format class
-  jclass colorSpaceClass = env->GetObjectClass(jColorSpace);
-  if (colorSpaceClass == nullptr) {
+  jclass color_space_class = env->GetObjectClass(j_color_space);
+  if (color_space_class == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_NULL;
   }
 
   // Set int type
-  jfieldID typeId = env->GetFieldID(colorSpaceClass, "type", "I");
-  if (typeId == nullptr) {
+  jfieldID type_id = env->GetFieldID(color_space_class, "type", "I");
+  if (type_id == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_TYPE_NULL;
   }
   int type = 65535; // Unmapped id to be used as unknown here
 
   // TODO(fraudies): Add support for more pixel formats
-  switch (pixelFormat.type) {
+  switch (pixelFormat.pixel_format_) {
   case AV_PIX_FMT_RGB24:
     type = TYPE_RGB;
     break;
   }
-  env->SetIntField(jColorSpace, typeId, type);
+  env->SetIntField(j_color_space, type_id, type);
 
   // Set number of color channels
-  jfieldID numChannelId =
-      env->GetFieldID(colorSpaceClass, "numComponents", "I");
-  if (typeId == nullptr) {
+  jfieldID num_channel_id =
+      env->GetFieldID(color_space_class, "numComponents", "I");
+  if (type_id == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_NUM_COMPONENT_NULL;
   }
-  env->SetIntField(jColorSpace, numChannelId, pixelFormat.numComponents);
+  env->SetIntField(j_color_space, num_channel_id, pixelFormat.num_components_);
 
   return ERROR_NONE;
 }
 
 // TODO: Might want to load field id's at init and cache thereafter (because of
 // performance bottleneck in JNI)
-uint32_t GetAudioFormat(JNIEnv *env, jobject jAudioFormat,
-                        AudioFormat *audioFormat) {
+uint32_t GetAudioFormat(JNIEnv *env, jobject j_audio_format,
+                        AudioFormat *p_audio_format) {
   // Get the audio format class
-  jclass audioFormatClass = env->GetObjectClass(jAudioFormat);
-  if (audioFormatClass == nullptr) {
+  jclass audio_format_class = env->GetObjectClass(j_audio_format);
+  if (audio_format_class == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_NULL;
   }
 
   // Get the audio encoding (nested class)
-  jfieldID encodingId =
-      env->GetFieldID(audioFormatClass, "encoding",
+  jfieldID encoding_id =
+      env->GetFieldID(audio_format_class, "encoding",
                       "Ljavax/sound/sampled/AudioFormat$Encoding;");
-  if (encodingId == nullptr) {
+  if (encoding_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_ID_NULL;
   }
-  jobject jEncoding = env->GetObjectField(jAudioFormat, encodingId);
-  if (jEncoding == nullptr) {
+  jobject j_encoding = env->GetObjectField(j_audio_format, encoding_id);
+  if (j_encoding == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_NULL;
   }
-  jclass encodingClass = env->GetObjectClass(jEncoding);
-  if (encodingClass == nullptr) {
+  jclass encoding_class = env->GetObjectClass(j_encoding);
+  if (encoding_class == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_CLASS_NULL;
   }
-  jfieldID encodingNameId =
-      env->GetFieldID(encodingClass, "name", "Ljava/lang/String;");
-  if (encodingNameId == nullptr) {
+  jfieldID encoding_name_id =
+      env->GetFieldID(encoding_class, "name", "Ljava/lang/String;");
+  if (encoding_name_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENCODING_NAME_ID_NULL;
   }
-  jstring jEncodingName =
-      (jstring)env->GetObjectField(jEncoding, encodingNameId);
-  int len = env->GetStringUTFLength(jEncodingName);
-  const char *encodingName = env->GetStringUTFChars(jEncodingName, 0);
-  audioFormat->encoding =
-      std::string(encodingName, env->GetStringUTFLength(jEncodingName));
-  env->ReleaseStringUTFChars(jEncodingName, encodingName);
+  jstring j_encoding_name =
+      (jstring)env->GetObjectField(j_encoding, encoding_name_id);
+  int len = env->GetStringUTFLength(j_encoding_name);
+  const char *encodingName = env->GetStringUTFChars(j_encoding_name, 0);
+  p_audio_format->encoding_name_ =
+      std::string(encodingName, env->GetStringUTFLength(j_encoding_name));
+  env->ReleaseStringUTFChars(j_encoding_name, encodingName);
 
   // Set endianess
-  jfieldID bigEndianId = env->GetFieldID(audioFormatClass, "bigEndian", "Z");
-  if (bigEndianId == nullptr) {
+  jfieldID big_endian_id = env->GetFieldID(audio_format_class, "bigEndian", "Z");
+  if (big_endian_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_ENDIAN_ID_NULL;
   }
-  audioFormat->bigEndian = env->GetBooleanField(jAudioFormat, bigEndianId);
+  p_audio_format->is_big_endian_ = env->GetBooleanField(j_audio_format, big_endian_id);
 
   // Set sample rate
-  jfieldID sampleRateId = env->GetFieldID(audioFormatClass, "sampleRate", "F");
-  if (sampleRateId == nullptr) {
+  jfieldID sample_rate_id = env->GetFieldID(audio_format_class, "sampleRate", "F");
+  if (sample_rate_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_SAMPLE_RATE_ID_NULL;
   }
-  audioFormat->sampleRate = env->GetFloatField(jAudioFormat, sampleRateId);
+  p_audio_format->sample_rate_ = env->GetFloatField(j_audio_format, sample_rate_id);
 
   // Set sample size in bits
-  jfieldID sampleSizeInBitsId =
-      env->GetFieldID(audioFormatClass, "sampleSizeInBits", "I");
-  if (sampleSizeInBitsId == nullptr) {
+  jfieldID sample_size_in_bits_id =
+      env->GetFieldID(audio_format_class, "sampleSizeInBits", "I");
+  if (sample_size_in_bits_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_SAMPLE_SIZE_IN_BITS_ID_NULL;
   }
-  audioFormat->sampleSizeInBits =
-      env->GetIntField(jAudioFormat, sampleSizeInBitsId);
+  p_audio_format->sample_size_in_bits_ =
+      env->GetIntField(j_audio_format, sample_size_in_bits_id);
 
   // Set the number of channels
-  jfieldID channelsId = env->GetFieldID(audioFormatClass, "channels", "I");
-  if (channelsId == nullptr) {
+  jfieldID channels_id = env->GetFieldID(audio_format_class, "channels", "I");
+  if (channels_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_CHANNELS_ID_NULL;
   }
-  audioFormat->channels = env->GetIntField(jAudioFormat, channelsId);
+  p_audio_format->num_channels_ = env->GetIntField(j_audio_format, channels_id);
 
   // Set the frame size in bytes
-  jfieldID frameSizeId = env->GetFieldID(audioFormatClass, "frameSize", "I");
-  if (frameSizeId == nullptr) {
+  jfieldID frame_size_id = env->GetFieldID(audio_format_class, "frameSize", "I");
+  if (frame_size_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_FRAME_SIZE_ID_NULL;
   }
-  audioFormat->frameSize = env->GetIntField(jAudioFormat, frameSizeId);
+  p_audio_format->frame_size_ = env->GetIntField(j_audio_format, frame_size_id);
 
   // Set the frame rate in Hertz
-  jfieldID frameRateId = env->GetFieldID(audioFormatClass, "frameRate", "F");
-  if (frameRateId == nullptr) {
+  jfieldID frame_rate_id = env->GetFieldID(audio_format_class, "frameRate", "F");
+  if (frame_rate_id == nullptr) {
     return ERROR_FFMPEG_AUDIO_FORMAT_FRAME_RATE_ID_NULL;
   }
-  audioFormat->frameRate = env->GetFloatField(jAudioFormat, frameRateId);
+  p_audio_format->frame_rate_ = env->GetFloatField(j_audio_format, frame_rate_id);
 
   return ERROR_NONE;
 }
 
-uint32_t GetPixelFormat(JNIEnv *env, jobject jColorSpace,
-                        PixelFormat *pixelFormat) {
+uint32_t GetPixelFormat(JNIEnv *env, jobject j_color_space,
+                        PixelFormat *p_pixel_format) {
 
   // Get the audio format class
-  jclass colorSpaceClass = env->GetObjectClass(jColorSpace);
-  if (colorSpaceClass == nullptr) {
+  jclass color_space_class = env->GetObjectClass(j_color_space);
+  if (color_space_class == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_NULL;
   }
 
   // Set int type
-  jfieldID typeId = env->GetFieldID(colorSpaceClass, "type", "I");
-  if (typeId == nullptr) {
+  jfieldID type_id = env->GetFieldID(color_space_class, "type", "I");
+  if (type_id == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_TYPE_NULL;
   }
-  int type = env->GetIntField(jColorSpace, typeId);
+  int type = env->GetIntField(j_color_space, type_id);
 
   // TODO(fraudies): Add support for more pixel formats
-  pixelFormat->type = AV_PIX_FMT_NONE;
+  p_pixel_format->pixel_format_ = AV_PIX_FMT_NONE;
   switch (type) {
   case TYPE_RGB:
-    pixelFormat->type = AV_PIX_FMT_RGB24; // CS_sRGB = 1000
+    p_pixel_format->pixel_format_ = AV_PIX_FMT_RGB24; // CS_sRGB = 1000
     break;
   }
 
   // Set number of color channels
-  jfieldID numChannelId =
-      env->GetFieldID(colorSpaceClass, "numComponents", "I");
-  if (typeId == nullptr) {
+  jfieldID num_channel_id =
+      env->GetFieldID(color_space_class, "numComponents", "I");
+  if (type_id == nullptr) {
     return ERROR_FFMPEG_COLOR_SPACE_NUM_COMPONENT_NULL;
   }
-  pixelFormat->numComponents = env->GetIntField(jColorSpace, numChannelId);
+  p_pixel_format->num_components_ = env->GetIntField(j_color_space, num_channel_id);
 
   return ERROR_NONE;
 }

--- a/src/main/cpp/FfmpegJniUtils.h
+++ b/src/main/cpp/FfmpegJniUtils.h
@@ -7,16 +7,16 @@
 // This mapping is taken from java.awt.color.ColorSpace.java
 #define TYPE_RGB 5
 
-uint32_t SetJAudioFormat(JNIEnv *env, jobject jAudioFormat,
-                         const AudioFormat &audioFormat);
+uint32_t SetJAudioFormat(JNIEnv *env, jobject j_audio_format,
+                         const AudioFormat &audio_format);
 
-uint32_t SetJPixelFormat(JNIEnv *env, jobject jPixelFormat,
-                         const PixelFormat &pixelFormat);
+uint32_t SetJPixelFormat(JNIEnv *env, jobject j_pixel_format,
+                         const PixelFormat &pixel_format);
 
-uint32_t GetAudioFormat(JNIEnv *env, jobject jAudioFormat,
-                        AudioFormat *audioFormat);
+uint32_t GetAudioFormat(JNIEnv *env, jobject j_audio_format,
+                        AudioFormat *p_audio_format);
 
-uint32_t GetPixelFormat(JNIEnv *env, jobject jPixelFormat,
-                        PixelFormat *pixelFormat);
+uint32_t GetPixelFormat(JNIEnv *env, jobject j_pixel_format,
+                        PixelFormat *p_pixel_format);
 
 #endif //_FFMPEG_JNI_UTILS_H_

--- a/src/main/cpp/FfmpegSdlAvPlayback.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlayback.cpp
@@ -44,38 +44,28 @@ const FfmpegSdlAvPlayback::TextureFormatEntry
         {AV_PIX_FMT_NONE, SDL_PIXELFORMAT_UNKNOWN},
 };
 
-inline int FfmpegSdlAvPlayback::compute_mod(int a, int b) {
-  return a < 0 ? a % b + b : a % b;
+void FfmpegSdlAvPlayback::SetSize(int width, int height) {
+  screen_width_ = frame_width_ = width;
+  screen_height_ = frame_height_ = height;
+  if (p_vis_texture_) {
+    SDL_DestroyTexture(p_vis_texture_);
+    p_vis_texture_ = NULL;
+  }
 }
 
-inline void FfmpegSdlAvPlayback::fill_rectangle(int x, int y, int w, int h) {
-  SDL_Rect rect;
-  rect.x = x;
-  rect.y = y;
-  rect.w = w;
-  rect.h = h;
-  if (w && h)
-    SDL_RenderFillRect(renderer, &rect);
-}
-
-void FfmpegSdlAvPlayback::calculate_display_rect(SDL_Rect *rect, int scr_xleft,
-                                                 int scr_ytop, int scr_width,
-                                                 int scr_height, int pic_width,
-                                                 int pic_height,
-                                                 AVRational pic_sar) {
-  float aspect_ratio;
+void FfmpegSdlAvPlayback::CalculateRectangleForDisplay(
+    SDL_Rect *rect, int scr_xleft, int scr_ytop, int scr_width, int scr_height,
+    int frame_width, int frame_height, AVRational frame_aspcet_ratio) {
   int width, height, x, y;
+  float aspect_ratio =
+      frame_aspcet_ratio.num == 0 ? 0 : av_q2d(frame_aspcet_ratio);
 
-  if (pic_sar.num == 0)
-    aspect_ratio = 0;
-  else
-    aspect_ratio = av_q2d(pic_sar);
-
-  if (aspect_ratio <= 0.0)
+  if (aspect_ratio <= 0.0) {
     aspect_ratio = 1.0;
-  aspect_ratio *= (float)pic_width / (float)pic_height;
+  }
+  aspect_ratio *= (float)frame_width / (float)frame_height;
 
-  /* XXX: we suppose the screen has a 1.0 pixel ratio */
+  // We suppose the screen has a 1.0 pixel ratio
   height = scr_height;
   width = lrint(height * aspect_ratio) & ~1;
   if (width > scr_width) {
@@ -91,11 +81,12 @@ void FfmpegSdlAvPlayback::calculate_display_rect(SDL_Rect *rect, int scr_xleft,
 }
 
 FfmpegSdlAvPlayback::FfmpegSdlAvPlayback(int startup_volume)
-    : FfmpegAvPlayback(), ytop(0), xleft(0), window(nullptr), renderer(nullptr),
-      img_convert_ctx(nullptr), vis_texture(nullptr), vid_texture(nullptr),
-      last_i_start(0), screen_width(0), screen_height(0), is_full_screen(0),
-      audio_volume(0), cursor_last_shown(0), cursor_hidden(0),
-      renderer_info({0}) {
+    : FfmpegAvPlayback(), y_top_(0), x_left_(0), p_window_(nullptr),
+      p_renderer_(nullptr), p_img_convert_ctx_(nullptr),
+      p_vis_texture_(nullptr), p_vid_texture_(nullptr), screen_width_(0),
+      screen_height_(0), enabled_full_screen_(0), audio_volume_(0),
+      cursor_last_shown_time_(0), is_cursor_hidden_(false),
+      renderer_info_({0}) {
 
   if (startup_volume < 0) {
     av_log(NULL, AV_LOG_WARNING, "-volume=%d < 0, setting to 0\n",
@@ -105,49 +96,89 @@ FfmpegSdlAvPlayback::FfmpegSdlAvPlayback(int startup_volume)
     av_log(NULL, AV_LOG_WARNING, "-volume=%d > 100, setting to 100\n",
            startup_volume);
   }
-  audio_volume =
+  audio_volume_ =
       av_clip(SDL_MIX_MAXVOLUME * av_clip(startup_volume, 0, 100) / 100, 0,
               SDL_MIX_MAXVOLUME);
 }
 
-FfmpegSdlAvPlayback::~FfmpegSdlAvPlayback() { av_free(window_title); }
+FfmpegSdlAvPlayback::~FfmpegSdlAvPlayback() {
 
-int FfmpegSdlAvPlayback::Init(const char *filename, AVInputFormat *iformat) {
+  StopDisplayLoop();
+
+  if (audio_dev_) {
+    CloseAudio();
+  }
+
+  delete p_video_state_;
+
+  // Cleanup textures
+  if (p_vis_texture_) {
+    SDL_DestroyTexture(p_vis_texture_);
+  }
+
+  if (p_vid_texture_) {
+    SDL_DestroyTexture(p_vid_texture_);
+  }
+
+  // Cleanup resampling
+  sws_freeContext(p_img_convert_ctx_);
+
+  // Cleanup SDL components
+  if (p_renderer_) {
+    SDL_DestroyRenderer(p_renderer_);
+  }
+
+  if (p_window_) {
+    SDL_DestroyWindow(p_window_);
+  }
+
+  avformat_network_deinit();
+
+  av_free(p_window_title_);
+
+  SDL_Quit();
+
+  av_log(NULL, AV_LOG_QUIET, "%s", "");
+}
+
+int FfmpegSdlAvPlayback::OpenVideo(const char *filename,
+                                   AVInputFormat *iformat) {
   /* register all codecs, demux and protocols */
 #if CONFIG_AVDEVICE
   avdevice_register_all();
 #endif
   avformat_network_init();
 
-  int err = FfmpegAvPlayback::Init(filename, iformat, kAudioMinBufferSize);
+  int err = FfmpegAvPlayback::OpenVideo(filename, iformat, kAudioMinBufferSize);
   if (err) {
     return err;
   }
 
-  if (!window_title)
-    window_title = av_asprintf("%s", filename);
+  if (!p_window_title_) {
+    p_window_title_ = av_asprintf("%s", filename);
+  }
 
   // Set callback functions
-  pVideoState->set_audio_open_callback(
+  p_video_state_->SetAudioOpenCallback(
       [this](int64_t wanted_channel_layout, int wanted_nb_channels,
              int wanted_sample_rate, struct AudioParams *audio_hw_params) {
-        return this->audio_open(wanted_channel_layout, wanted_nb_channels,
-                                wanted_sample_rate, audio_hw_params);
+        return this->OpenAudio(wanted_channel_layout, wanted_nb_channels,
+                               wanted_sample_rate, audio_hw_params);
       });
-  pVideoState->set_pause_audio_device_callback(
-      [this] { this->pauseAudioDevice(); });
-  pVideoState->set_destroy_callback([this] { this->destroy(); });
-  pVideoState->set_step_to_next_frame_callback(
-      [this] { this->step_to_next_frame(); });
+  p_video_state_->SetPauseAudioDeviceCallback(
+      [this] { this->PauseAudio(); });
+  p_video_state_->SetDestroyCallback([this] { delete this; });
+  p_video_state_->SetStepToNextFrameCallback(
+      [this] { this->StepToNextFrame(); });
 
   return ERROR_NONE;
 }
 
 /* Public Members */
-int FfmpegSdlAvPlayback::audio_open(int64_t wanted_channel_layout,
-                                    int wanted_nb_channels,
-                                    int wanted_sample_rate,
-                                    struct AudioParams *audio_hw_params) {
+int FfmpegSdlAvPlayback::OpenAudio(int64_t wanted_channel_layout,
+                                   int wanted_nb_channels,
+                                   int wanted_sample_rate,
+                                   struct AudioParams *audio_hw_params) {
   SDL_AudioSpec wanted_spec, spec;
   const char *env;
   static const int next_nb_channels[] = {0, 0, 1, 6, 2, 6, 4, 6};
@@ -182,10 +213,10 @@ int FfmpegSdlAvPlayback::audio_open(int64_t wanted_channel_layout,
             2 << av_log2(wanted_spec.freq / kAudioMaxCallbackPerSec));
   wanted_spec.callback = sdl_audio_callback_bridge;
   wanted_spec.userdata = this;
-  while (
-      !(audio_dev = SDL_OpenAudioDevice(NULL, 0, &wanted_spec, &spec,
-                                        SDL_AUDIO_ALLOW_FREQUENCY_CHANGE |
-                                            SDL_AUDIO_ALLOW_CHANNELS_CHANGE))) {
+  while (!(audio_dev_ =
+               SDL_OpenAudioDevice(NULL, 0, &wanted_spec, &spec,
+                                   SDL_AUDIO_ALLOW_FREQUENCY_CHANGE |
+                                       SDL_AUDIO_ALLOW_CHANNELS_CHANGE))) {
     av_log(NULL, AV_LOG_WARNING, "SDL_OpenAudio (%d channels, %d Hz): %s\n",
            wanted_spec.channels, wanted_spec.freq, SDL_GetError());
     wanted_spec.channels = next_nb_channels[FFMIN(7, wanted_spec.channels)];
@@ -230,67 +261,49 @@ int FfmpegSdlAvPlayback::audio_open(int64_t wanted_channel_layout,
   return spec.size;
 }
 
-int FfmpegSdlAvPlayback::video_open(const char *filename) {
-  int w, h;
+int FfmpegSdlAvPlayback::OpenWindow(const char *window_name) {
 
-  if (screen_width) {
-    w = screen_width;
-    h = screen_height;
+  if (IsScreenSizeSet()) {
+    frame_width_ = screen_width_;
+    frame_height_ = screen_height_;
   } else {
-    w = kDefaultWidth;
-    h = kDefaultHeight;
+    frame_width_ = kDefaultWidth;
+    frame_height_ = kDefaultHeight;
   }
+  p_window_title_ = av_strdup(window_name);
 
-  window_title = av_strdup(filename);
-
-  SDL_SetWindowTitle(window, window_title);
-  SDL_SetWindowSize(window, w, h);
-  SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-  if (is_full_screen)
-    SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-  SDL_ShowWindow(window);
-
-  width = w;
-  height = h;
+  SDL_SetWindowTitle(p_window_, p_window_title_);
+  SDL_SetWindowSize(p_window_, frame_width_, frame_height_);
+  SDL_SetWindowPosition(p_window_, SDL_WINDOWPOS_CENTERED,
+                        SDL_WINDOWPOS_CENTERED);
+  if (enabled_full_screen_) {
+    SDL_SetWindowFullscreen(p_window_, SDL_WINDOW_FULLSCREEN_DESKTOP);
+  }
+  SDL_ShowWindow(p_window_);
 
   return 0;
 }
 
-void FfmpegSdlAvPlayback::set_default_window_size(int width, int height,
-                                                  AVRational sar) {
+void FfmpegSdlAvPlayback::SetDefaultWindowSize(int width, int height,
+                                               AVRational sar) {
   SDL_Rect rect;
-  calculate_display_rect(&rect, 0, 0, INT_MAX, height, width, height, sar);
+  CalculateRectangleForDisplay(&rect, 0, 0, INT_MAX, height, width, height,
+                               sar);
   kDefaultWidth = rect.w;
   kDefaultHeight = rect.h;
 }
 
-void FfmpegSdlAvPlayback::closeAudioDevice() {
-  SDL_CloseAudioDevice(audio_dev);
-}
-
-void FfmpegSdlAvPlayback::pauseAudioDevice() {
-  SDL_PauseAudioDevice(audio_dev, 0);
-}
-
-VideoState *FfmpegSdlAvPlayback::get_VideoState() { return pVideoState; }
-
-void FfmpegSdlAvPlayback::toggle_full_screen() {
-  is_full_screen = !is_full_screen;
-  SDL_SetWindowFullscreen(window,
-                          is_full_screen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
-}
-
-int FfmpegSdlAvPlayback::upload_texture(SDL_Texture **tex, AVFrame *frame,
-                                        struct SwsContext **img_convert_ctx) {
+int FfmpegSdlAvPlayback::UploadTexture(SDL_Texture **tex, AVFrame *frame,
+                                       struct SwsContext **img_convert_ctx) {
   int ret = 0;
   Uint32 sdl_pix_fmt;
   SDL_BlendMode sdl_blendmode;
-  get_sdl_pix_fmt_and_blendmode(frame->format, &sdl_pix_fmt, &sdl_blendmode);
-  if (realloc_texture(tex,
-                      sdl_pix_fmt == SDL_PIXELFORMAT_UNKNOWN
-                          ? SDL_PIXELFORMAT_ARGB8888
-                          : sdl_pix_fmt,
-                      frame->width, frame->height, sdl_blendmode, 0) < 0)
+  GetPixelFormatAndBlendmode(frame->format, &sdl_pix_fmt, &sdl_blendmode);
+  if (ReallocateTexture(tex,
+                        sdl_pix_fmt == SDL_PIXELFORMAT_UNKNOWN
+                            ? SDL_PIXELFORMAT_ARGB8888
+                            : sdl_pix_fmt,
+                        frame->width, frame->height, sdl_blendmode, 0) < 0)
     return -1;
   switch (sdl_pix_fmt) {
   case SDL_PIXELFORMAT_UNKNOWN:
@@ -348,7 +361,7 @@ int FfmpegSdlAvPlayback::upload_texture(SDL_Texture **tex, AVFrame *frame,
   return ret;
 }
 
-void FfmpegSdlAvPlayback::get_sdl_pix_fmt_and_blendmode(
+void FfmpegSdlAvPlayback::GetPixelFormatAndBlendmode(
     int format, Uint32 *sdl_pix_fmt, SDL_BlendMode *sdl_blendmode) {
   int i;
   *sdl_blendmode = SDL_BLENDMODE_NONE;
@@ -364,11 +377,11 @@ void FfmpegSdlAvPlayback::get_sdl_pix_fmt_and_blendmode(
   }
 }
 
-int FfmpegSdlAvPlayback::realloc_texture(SDL_Texture **texture,
-                                         Uint32 new_format, int new_width,
-                                         int new_height,
-                                         SDL_BlendMode blendmode,
-                                         int init_texture) {
+int FfmpegSdlAvPlayback::ReallocateTexture(SDL_Texture **texture,
+                                           Uint32 new_format, int new_width,
+                                           int new_height,
+                                           SDL_BlendMode blendmode,
+                                           int init_texture) {
   Uint32 format;
   int access, w, h;
   if (!*texture || SDL_QueryTexture(*texture, &format, &access, &w, &h) < 0 ||
@@ -377,7 +390,7 @@ int FfmpegSdlAvPlayback::realloc_texture(SDL_Texture **texture,
     int pitch;
     if (*texture)
       SDL_DestroyTexture(*texture);
-    if (!(*texture = SDL_CreateTexture(renderer, new_format,
+    if (!(*texture = SDL_CreateTexture(p_renderer_, new_format,
                                        SDL_TEXTUREACCESS_STREAMING, new_width,
                                        new_height)))
       return -1;
@@ -395,143 +408,148 @@ int FfmpegSdlAvPlayback::realloc_texture(SDL_Texture **texture,
   return 0;
 }
 
-void FfmpegSdlAvPlayback::video_display() {
-  if (!width)
-    video_open(pVideoState->get_filename());
-
-  SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
-  SDL_RenderClear(renderer);
-  if (pVideoState->get_video_st())
-    video_image_display();
-  SDL_RenderPresent(renderer);
-}
-
-void FfmpegSdlAvPlayback::video_image_display() {
-  Frame *vp;
-  SDL_Rect rect;
-
-  vp = pVideoState->get_pPictq()->peek_last();
-
-  calculate_display_rect(&rect, this->xleft, this->ytop, this->width,
-                         this->height, vp->width, vp->height, vp->sar);
-
-  if (!vp->uploaded) {
-    if (upload_texture(&vid_texture, vp->frame, &img_convert_ctx) < 0)
-      return;
-    vp->uploaded = 1;
-    vp->flip_v = vp->frame->linesize[0] < 0;
+void FfmpegSdlAvPlayback::DisplayVideoFrame() {
+  if (!frame_width_) {
+    OpenWindow(p_video_state_->get_filename());
   }
 
-  SDL_RenderCopyEx(renderer, vid_texture, NULL, &rect, 0, NULL,
-                   vp->flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE);
+  SDL_SetRenderDrawColor(p_renderer_, 0, 0, 0, 255);
+  SDL_RenderClear(p_renderer_);
+  if (p_video_state_->get_video_st()) {
+    GetAndDisplayVideoFrame();
+  }
+  SDL_RenderPresent(p_renderer_);
 }
 
-int FfmpegSdlAvPlayback::get_audio_volume() const { return audio_volume; }
+void FfmpegSdlAvPlayback::GetAndDisplayVideoFrame() {
+  Frame *p_frame;
+  SDL_Rect rect;
 
-void FfmpegSdlAvPlayback::update_volume(int sign, double step) {
-  int audio_volume = get_audio_volume();
-  double volume_level =
-      audio_volume
-          ? (20 * log(audio_volume / (double)SDL_MIX_MAXVOLUME) / log(10))
-          : -1000.0;
-  int new_volume =
-      lrint(SDL_MIX_MAXVOLUME * pow(10.0, (volume_level + sign * step) / 20.0));
-  audio_volume =
-      av_clip(audio_volume == new_volume ? (audio_volume + sign) : new_volume,
-              0, SDL_MIX_MAXVOLUME);
+  p_frame = p_video_state_->get_pPictq()->peek_last();
+
+  CalculateRectangleForDisplay(&rect, this->x_left_, this->y_top_, this->frame_width_,
+                               this->frame_height_, p_frame->width, p_frame->height,
+                               p_frame->aspect_ration);
+
+  if (!p_frame->uploaded) {
+    if (UploadTexture(&p_vid_texture_, p_frame->frame, &p_img_convert_ctx_) < 0)
+      return;
+    p_frame->uploaded = 1;
+    p_frame->flip_v = p_frame->frame->linesize[0] < 0;
+  }
+
+  SDL_RenderCopyEx(p_renderer_, p_vid_texture_, NULL, &rect, 0, NULL,
+                   p_frame->flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE);
 }
 
-void FfmpegSdlAvPlayback::refresh_loop_wait_event(SDL_Event *event) {
+int FfmpegSdlAvPlayback::GetVolumeStep() const {
+  return audio_volume_
+             ? (20 * log(audio_volume_ / (double)SDL_MIX_MAXVOLUME) / log(10))
+             : -1000.0;
+}
+
+void FfmpegSdlAvPlayback::StepVolume(double stepInDecibel) {
+  double volume_level = GetVolumeStep();
+  int new_volume = lrint(SDL_MIX_MAXVOLUME *
+                         pow(10.0, (volume_level + stepInDecibel) / 20.0));
+  audio_volume_ =
+      av_clip(audio_volume_ == new_volume ? audio_volume_ : new_volume, 0,
+              SDL_MIX_MAXVOLUME);
+}
+
+void FfmpegSdlAvPlayback::SetVolume(double volume) { audio_volume_ = FFMAX(0, volume); }
+
+void FfmpegSdlAvPlayback::DisplayAndProcessEvent(SDL_Event *event) {
   double remaining_time = 0.0;
   SDL_PumpEvents();
   while (
       !SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT)) {
-    if (!cursor_hidden &&
-        av_gettime_relative() - cursor_last_shown > kCursorHideDelayInMillis) {
+    if (!is_cursor_hidden_ && av_gettime_relative() - cursor_last_shown_time_ >
+                                  kCursorHideDelayInMillis) {
       SDL_ShowCursor(0);
-      cursor_hidden = 1;
+      is_cursor_hidden_ = true;
     }
     if (remaining_time > 0.0)
       av_usleep((int64_t)(remaining_time * 1000000.0));
     remaining_time = kRefreshRate;
-    if (!pVideoState->get_paused() || force_refresh)
-      video_refresh(&remaining_time);
+    if (!p_video_state_->get_paused() || force_refresh_)
+      UpdateFrame(&remaining_time);
     SDL_PumpEvents();
   }
 }
 
-void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
+void FfmpegSdlAvPlayback::UpdateFrame(double *remaining_time) {
   double time;
 
   Frame *sp, *sp2;
 
-  if (pVideoState->get_video_st()) {
+  if (p_video_state_->get_video_st()) {
   retry:
-    if (pVideoState->get_pPictq()->nb_remaining() == 0) {
+    if (p_video_state_->get_pPictq()->nb_remaining() == 0) {
       // nothing to do, no picture to display in the queue
     } else {
       double last_duration, duration, delay;
       Frame *vp, *lastvp;
 
       /* dequeue the picture */
-      lastvp = pVideoState->get_pPictq()->peek_last();
-      vp = pVideoState->get_pPictq()->peek();
+      lastvp = p_video_state_->get_pPictq()->peek_last();
+      vp = p_video_state_->get_pPictq()->peek();
 
-      if (vp->serial != pVideoState->get_pVideoq()->get_serial()) {
-        pVideoState->get_pPictq()->next();
+      if (vp->serial != p_video_state_->get_pVideoq()->get_serial()) {
+        p_video_state_->get_pPictq()->next();
         goto retry;
       }
 
       if (lastvp->serial != vp->serial)
-        frame_timer = av_gettime_relative() / 1000000.0;
+        frame_last_shown_time_ = av_gettime_relative() / 1000000.0;
 
       // Force refresh overrides paused
-      if (pVideoState->get_paused() && !force_refresh)
+      if (p_video_state_->get_paused() && !force_refresh_)
         goto display;
 
       /* compute nominal last_duration */
       last_duration =
-          vp_duration(lastvp, vp, pVideoState->get_max_frame_duration());
-      delay = pVideoState->compute_target_delay(last_duration);
+          ComputeFrameDuration(lastvp, vp, p_video_state_->get_max_frame_duration());
+      delay = p_video_state_->compute_target_delay(last_duration);
 
       time = av_gettime_relative() / 1000000.0;
-      if (time < frame_timer + delay) {
-        *remaining_time = FFMIN(frame_timer + delay - time, *remaining_time);
+      if (time < frame_last_shown_time_ + delay) {
+        *remaining_time = FFMIN(frame_last_shown_time_ + delay - time, *remaining_time);
         goto display;
       }
 
-      frame_timer += delay;
-      if (delay > 0 && time - frame_timer > VideoState::kAvSyncThresholdMax)
-        frame_timer = time;
+      frame_last_shown_time_ += delay;
+      if (delay > 0 && time - frame_last_shown_time_ > VideoState::kAvSyncThresholdMax)
+        frame_last_shown_time_ = time;
 
       std::unique_lock<std::mutex> locker(
-          pVideoState->get_pPictq()->get_mutex());
+          p_video_state_->get_pPictq()->get_mutex());
       if (!isnan(vp->pts))
-        pVideoState->update_pts(vp->pts, vp->serial);
+        p_video_state_->update_pts(vp->pts, vp->serial);
       locker.unlock();
 
-      if (pVideoState->get_pPictq()->nb_remaining() > 1) {
-        Frame *nextvp = pVideoState->get_pPictq()->peek_next();
+      if (p_video_state_->get_pPictq()->nb_remaining() > 1) {
+        Frame *nextvp = p_video_state_->get_pPictq()->peek_next();
         duration =
-            vp_duration(vp, nextvp, pVideoState->get_max_frame_duration());
-        if (!pVideoState->get_step() && time > frame_timer + duration) {
-          frame_drops_late++;
-          pVideoState->get_pPictq()->next();
+            ComputeFrameDuration(vp, nextvp, p_video_state_->get_max_frame_duration());
+        if (!p_video_state_->IsStepping() && time > frame_last_shown_time_ + duration) {
+          num_frame_drops_late_++;
+          p_video_state_->get_pPictq()->next();
           goto retry;
         }
       }
 
-      pVideoState->get_pPictq()->next();
-      force_refresh = 1;
+      p_video_state_->get_pPictq()->next();
+      force_refresh_ = 1;
     }
   display:
     /* display picture */
-    if (!display_disable && force_refresh &&
-        pVideoState->get_pPictq()->get_rindex_shown()) {
-      video_display();
-      force_refresh = 0; // only reset force refresh when displayed
-      if (pVideoState->get_step() && !pVideoState->get_paused())
-        stream_toggle_pause();
+    if (!display_disabled_ && force_refresh_ &&
+        p_video_state_->get_pPictq()->get_rindex_shown()) {
+      DisplayVideoFrame();
+      force_refresh_ = 0; // only reset force refresh when displayed
+      if (p_video_state_->IsStepping() && !p_video_state_->get_paused())
+        TogglePause();
     }
   }
   if (kEnableShowStatus) {
@@ -545,40 +563,41 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
       aqsize = 0;
       vqsize = 0;
       sqsize = 0;
-      if (pVideoState->get_audio_st()) {
-        aqsize = pVideoState->get_pAudioq()->get_size();
+      if (p_video_state_->get_audio_st()) {
+        aqsize = p_video_state_->get_pAudioq()->get_size();
       }
-      if (pVideoState->get_video_st()) {
-        vqsize = pVideoState->get_pVideoq()->get_size();
+      if (p_video_state_->get_video_st()) {
+        vqsize = p_video_state_->get_pVideoq()->get_size();
       }
       av_diff = 0;
-      if (pVideoState->get_audio_st() && pVideoState->get_video_st()) {
-        av_diff = pVideoState->get_pAudclk()->get_time() -
-                  pVideoState->get_pVidclk()->get_time();
-      } else if (pVideoState->get_video_st()) {
-        av_diff = pVideoState->get_master_clock()->get_time() -
-                  pVideoState->get_pVidclk()->get_time();
-      } else if (pVideoState->get_audio_st()) {
-        av_diff = pVideoState->get_master_clock()->get_time() -
-                  pVideoState->get_pAudclk()->get_time();
+      if (p_video_state_->get_audio_st() && p_video_state_->get_video_st()) {
+        av_diff = p_video_state_->get_pAudclk()->get_time() -
+                  p_video_state_->get_pVidclk()->get_time();
+      } else if (p_video_state_->get_video_st()) {
+        av_diff = p_video_state_->get_master_clock()->get_time() -
+                  p_video_state_->get_pVidclk()->get_time();
+      } else if (p_video_state_->get_audio_st()) {
+        av_diff = p_video_state_->get_master_clock()->get_time() -
+                  p_video_state_->get_pAudclk()->get_time();
       }
-      av_log(NULL, AV_LOG_INFO,
-             "%7.2f at %1.3fX vc=%5.2f %s:%7.3f de=%4d dl=%4d aq=%5dKB "
-             "vq=%5dKB sq=%5dB f=%f /%f   \r",
-             pVideoState->get_master_clock()->get_time(),
-             pVideoState->get_rate(), pVideoState->get_pVidclk()->get_time(),
-             (pVideoState->get_audio_st() && pVideoState->get_video_st())
-                 ? "A-V"
-                 : (pVideoState->get_video_st()
-                        ? "M-V"
-                        : (pVideoState->get_audio_st() ? "M-A" : "   ")),
-             av_diff, pVideoState->get_frame_drops_early(), frame_drops_late,
-             aqsize / 1024, vqsize / 1024, sqsize,
-             pVideoState->get_video_st() ? pVideoState->get_pViddec()
+      av_log(
+          NULL, AV_LOG_INFO,
+          "%7.2f at %1.3fX vc=%5.2f %s:%7.3f de=%4d dl=%4d aq=%5dKB "
+          "vq=%5dKB sq=%5dB f=%f /%f   \r",
+          p_video_state_->get_master_clock()->get_time(),
+          p_video_state_->GetSpeed(), p_video_state_->get_pVidclk()->get_time(),
+          (p_video_state_->get_audio_st() && p_video_state_->get_video_st())
+              ? "A-V"
+              : (p_video_state_->get_video_st()
+                     ? "M-V"
+                     : (p_video_state_->get_audio_st() ? "M-A" : "   ")),
+          av_diff, p_video_state_->get_frame_drops_early(), num_frame_drops_late_,
+          aqsize / 1024, vqsize / 1024, sqsize,
+          p_video_state_->get_video_st() ? p_video_state_->get_pViddec()
                                                ->get_avctx()
                                                ->pts_correction_num_faulty_dts
                                          : 0,
-             pVideoState->get_video_st() ? pVideoState->get_pViddec()
+          p_video_state_->get_video_st() ? p_video_state_->get_pViddec()
                                                ->get_avctx()
                                                ->pts_correction_num_faulty_pts
                                          : 0);
@@ -588,28 +607,30 @@ void FfmpegSdlAvPlayback::video_refresh(double *remaining_time) {
   }
 }
 
-void FfmpegSdlAvPlayback::InitSdl() {
+void FfmpegSdlAvPlayback::Initialize() {
 
-  if (pVideoState->get_image_width()) {
-    FfmpegSdlAvPlayback::set_default_window_size(
-        pVideoState->get_image_width(), pVideoState->get_image_height(),
-        pVideoState->get_image_sample_aspect_ratio());
+  if (p_video_state_->GetFrameWidth()) {
+    FfmpegSdlAvPlayback::SetDefaultWindowSize(
+        p_video_state_->GetFrameWidth(), p_video_state_->GetFrameHeight(),
+        p_video_state_->GetFrameAspectRatio());
   }
 
-  if (display_disable) {
-    pVideoState->set_video_disable(1);
+  if (display_disabled_) {
+    p_video_state_->SetVideoDisabled(1);
   }
   int flags = SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER;
-  if (pVideoState->get_audio_disable())
+  if (p_video_state_->GetAudioDisabled()) {
     flags &= ~SDL_INIT_AUDIO;
-  else {
+  } else {
     /* Try to work around an occasional ALSA buffer underflow issue when the
      * period size is NPOT due to ALSA resampling by forcing the buffer size. */
-    if (!SDL_getenv("SDL_AUDIO_ALSA_SET_BUFFER_SIZE"))
+    if (!SDL_getenv("SDL_AUDIO_ALSA_SET_BUFFER_SIZE")) {
       SDL_setenv("SDL_AUDIO_ALSA_SET_BUFFER_SIZE", "1", 1);
+    }
   }
-  if (display_disable)
+  if (display_disabled_) {
     flags &= ~SDL_INIT_VIDEO;
+  }
   if (SDL_Init(flags)) {
     av_log(NULL, AV_LOG_FATAL, "Could not initialize SDL - %s\n",
            SDL_GetError());
@@ -620,146 +641,112 @@ void FfmpegSdlAvPlayback::InitSdl() {
   SDL_EventState(SDL_SYSWMEVENT, SDL_IGNORE);
   SDL_EventState(SDL_USEREVENT, SDL_IGNORE);
 
-  if (!display_disable) {
+  if (!display_disabled_) {
     int flags = SDL_WINDOW_HIDDEN;
     if (kWindowResizable) {
       flags |= SDL_WINDOW_RESIZABLE;
     } else {
       flags |= SDL_WINDOW_BORDERLESS;
     }
-    window = SDL_CreateWindow(kDefaultWindowTitle, SDL_WINDOWPOS_UNDEFINED,
-                              SDL_WINDOWPOS_UNDEFINED, kDefaultWidth,
-                              kDefaultHeight, flags);
+    p_window_ = SDL_CreateWindow(kDefaultWindowTitle, SDL_WINDOWPOS_UNDEFINED,
+                                 SDL_WINDOWPOS_UNDEFINED, kDefaultWidth,
+                                 kDefaultHeight, flags);
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-    if (window) {
-      renderer = SDL_CreateRenderer(
-          window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
-      if (!renderer) {
+    if (p_window_) {
+      p_renderer_ = SDL_CreateRenderer(
+          p_window_, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+      if (!p_renderer_) {
         av_log(NULL, AV_LOG_WARNING,
                "Failed to initialize a hardware accelerated renderer: %s\n",
                SDL_GetError());
-        renderer = SDL_CreateRenderer(window, -1, 0);
+        p_renderer_ = SDL_CreateRenderer(p_window_, -1, 0);
       }
-      if (renderer) {
-        if (!SDL_GetRendererInfo(renderer, &renderer_info))
+      if (p_renderer_) {
+        if (!SDL_GetRendererInfo(p_renderer_, &renderer_info_))
           av_log(NULL, AV_LOG_VERBOSE, "Initialized %s renderer.\n",
-                 renderer_info.name);
+                 renderer_info_.name);
       }
     }
-    if (!window || !renderer || !renderer_info.num_texture_formats) {
+    if (!p_window_ || !p_renderer_ || !renderer_info_.num_texture_formats) {
       av_log(NULL, AV_LOG_FATAL, "Failed to create window or renderer: %s",
              SDL_GetError());
-      if (renderer)
-        SDL_DestroyRenderer(renderer);
-      if (window)
-        SDL_DestroyWindow(window);
+      if (p_renderer_)
+        SDL_DestroyRenderer(p_renderer_);
+      if (p_window_)
+        SDL_DestroyWindow(p_window_);
     }
   }
 }
 
-void FfmpegSdlAvPlayback::destroy() {
-
-  stop_display_loop();
-
-  if (audio_dev) {
-    closeAudioDevice();
-  }
-
-  delete pVideoState;
-
-  // Cleanup textures
-  if (vis_texture) {
-    SDL_DestroyTexture(vis_texture);
-  }
-
-  if (vid_texture) {
-    SDL_DestroyTexture(vid_texture);
-  }
-
-  // Cleanup resampling
-  sws_freeContext(img_convert_ctx);
-
-  // Cleanup SDL components
-  if (renderer) {
-    SDL_DestroyRenderer(renderer);
-  }
-
-  if (window) {
-    SDL_DestroyWindow(window);
-  }
-
-  avformat_network_deinit();
-
-  SDL_Quit();
-
-  av_log(NULL, AV_LOG_QUIET, "%s", "");
-}
-
-void FfmpegSdlAvPlayback::init_and_event_loop() {
+void FfmpegSdlAvPlayback::InitializeAndListenForEvents(
+    FfmpegSdlAvPlayback *p_player) {
   SDL_Event event;
   double incr, pos, frac, rate;
-  // Initialize first before starting the stream
-  InitSdl();
-  pVideoState->stream_start();
+
+  // Initialize before starting the stream
+  p_player->Initialize();
+  VideoState *p_video_state = nullptr;
+  p_player->GetVideoState(&p_video_state);
+  p_video_state->StartStream();
   rate = 1;
 
-  if (pVideoState->get_image_width()) {
-    FfmpegSdlAvPlayback::set_default_window_size(
-        pVideoState->get_image_width(), pVideoState->get_image_height(),
-        pVideoState->get_image_sample_aspect_ratio());
+  if (p_video_state->GetFrameWidth()) {
+    FfmpegSdlAvPlayback::SetDefaultWindowSize(
+        p_video_state->GetFrameWidth(), p_video_state->GetFrameHeight(),
+        p_video_state->GetFrameAspectRatio());
   }
 
   for (;;) {
     double x;
-    refresh_loop_wait_event(&event);
+    p_player->DisplayAndProcessEvent(&event);
     switch (event.type) {
     case SDL_KEYDOWN:
       switch (event.key.keysym.sym) {
       case SDLK_ESCAPE:
       case SDLK_q:
-        destroy();
+        delete p_player;
         exit(0); // need to exit here to avoid joinable exception
         break;
       case SDLK_f:
-        toggle_full_screen();
-        force_refresh = 1;
+        p_player->ToggleFullscreen();
+        p_player->set_force_refresh(true);
         break;
       case SDLK_KP_8:
-        play();
+        p_player->Play();
         break;
       case SDLK_KP_5:
-        stop();
+        p_player->Stop();
         break;
       case SDLK_KP_2:
-        toggle_pause();
+        p_player->TogglePauseAndStopStep();
         break;
       case SDLK_p:
       case SDLK_SPACE:
-        toggle_pause();
+        p_player->TogglePauseAndStopStep();
         break;
       case SDLK_m:
-        pVideoState->toggle_mute();
+        p_video_state->toggle_mute();
         break;
       case SDLK_KP_MULTIPLY:
       case SDLK_0:
-        update_volume(1, kVolumeStepInDecibel);
+        p_player->StepVolume(+kVolumeStepInDecibel);
         break;
       case SDLK_KP_DIVIDE:
       case SDLK_9:
-        update_volume(-1, kVolumeStepInDecibel);
+        p_player->StepVolume(-kVolumeStepInDecibel);
         break;
       case SDLK_s: // S: Step to next frame
-        step_to_next_frame();
+        p_player->StepToNextFrame();
         break;
       case SDLK_KP_PLUS:
-        if (pVideoState->set_rate(rate * 2)) {
+        if (p_video_state->SetSpeed(rate * 2)) {
           av_log(NULL, AV_LOG_ERROR, "Rate %f unavailable\n", rate * 2);
         } else {
           rate *= 2;
         }
         break;
       case SDLK_KP_MINUS:
-        if (pVideoState->set_rate(rate / 2)) {
+        if (p_video_state->SetSpeed(rate / 2)) {
           av_log(NULL, AV_LOG_ERROR, "Rate %f unavailable\n", rate / 2);
         } else {
           rate /= 2;
@@ -780,29 +767,29 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
         // TODO FIX SEEK BY BYTES BUG
         if (VideoState::kEnableSeekByBytes) {
           pos = -1;
-          if (pos < 0 && pVideoState->get_video_stream() >= 0)
-            pos = pVideoState->get_pPictq()->last_pos();
-          if (pos < 0 && pVideoState->get_audio_stream() >= 0)
-            pos = pVideoState->get_pSampq()->last_pos();
+          if (pos < 0 && p_video_state->get_video_stream() >= 0)
+            pos = p_video_state->get_pPictq()->last_pos();
+          if (pos < 0 && p_video_state->get_audio_stream() >= 0)
+            pos = p_video_state->get_pSampq()->last_pos();
           if (pos < 0)
-            pos = avio_tell(pVideoState->get_ic()->pb);
-          if (pVideoState->get_ic()->bit_rate)
-            incr *= pVideoState->get_ic()->bit_rate / 8.0;
+            pos = avio_tell(p_video_state->get_ic()->pb);
+          if (p_video_state->get_ic()->bit_rate)
+            incr *= p_video_state->get_ic()->bit_rate / 8.0;
           else
             incr *= 180000.0;
           pos += incr;
-          pVideoState->stream_seek(pos, incr, 1);
+          p_video_state->stream_seek(pos, incr, 1);
         } else {
-          pos = pVideoState->get_master_clock()->get_time();
+          pos = p_video_state->get_master_clock()->get_time();
           if (isnan(pos)) {
-            pos = (double)pVideoState->get_seek_pos() / AV_TIME_BASE;
+            pos = (double)p_video_state->get_seek_pos() / AV_TIME_BASE;
           }
           pos += incr;
-          if (pVideoState->get_ic()->start_time != AV_NOPTS_VALUE &&
-              pos < pVideoState->get_ic()->start_time / (double)AV_TIME_BASE)
-            pos = pVideoState->get_ic()->start_time / (double)AV_TIME_BASE;
-          pVideoState->stream_seek((int64_t)(pos * AV_TIME_BASE),
-                                   (int64_t)(incr * AV_TIME_BASE), 0);
+          if (p_video_state->get_ic()->start_time != AV_NOPTS_VALUE &&
+              pos < p_video_state->get_ic()->start_time / (double)AV_TIME_BASE)
+            pos = p_video_state->get_ic()->start_time / (double)AV_TIME_BASE;
+          p_video_state->stream_seek((int64_t)(pos * AV_TIME_BASE),
+                                     (int64_t)(incr * AV_TIME_BASE), 0);
         }
         break;
       default:
@@ -813,19 +800,22 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
       if (event.button.button == SDL_BUTTON_LEFT) {
         static int64_t last_mouse_left_click = 0;
         if (av_gettime_relative() - last_mouse_left_click <= 500000) {
-          toggle_full_screen();
-          force_refresh = 1;
+          p_player->ToggleFullscreen();
+          p_player->set_force_refresh(true);
           last_mouse_left_click = 0;
         } else {
           last_mouse_left_click = av_gettime_relative();
         }
       }
     case SDL_MOUSEMOTION:
-      if (cursor_hidden) {
+      if (p_player->IsCursorHidden()) {
         SDL_ShowCursor(1);
-        cursor_hidden = 0;
+        p_player->SetIsCursorHidden(false);
       }
-      cursor_last_shown = av_gettime_relative();
+      p_player->SetCursorLastShownTime(av_gettime_relative());
+      int width;
+      int height;
+      p_player->GetSize(&width, &height);
       if (event.type == SDL_MOUSEBUTTONDOWN) {
         if (event.button.button != SDL_BUTTON_RIGHT)
           break;
@@ -836,14 +826,14 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
         x = event.motion.x;
       }
       if (VideoState::kEnableSeekByBytes ||
-          pVideoState->get_ic()->duration <= 0) {
-        uint64_t size = avio_size(pVideoState->get_ic()->pb);
-        pVideoState->stream_seek(size * x / width, 0, 1);
+          p_video_state->get_ic()->duration <= 0) {
+        uint64_t size = avio_size(p_video_state->get_ic()->pb);
+        p_video_state->stream_seek(size * x / width, 0, 1);
       } else {
         int64_t ts;
         int ns, hh, mm, ss;
         int tns, thh, tmm, tss;
-        tns = pVideoState->get_ic()->duration / 1000000LL;
+        tns = p_video_state->get_ic()->duration / 1000000LL;
         thh = tns / 3600;
         tmm = (tns % 3600) / 60;
         tss = (tns % 60);
@@ -856,28 +846,23 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
                "Seek to %2.0f%% (%2d:%02d:%02d) of total duration "
                "(%2d:%02d:%02d)       \n",
                frac * 100, hh, mm, ss, thh, tmm, tss);
-        ts = frac * pVideoState->get_ic()->duration;
-        if (pVideoState->get_ic()->start_time != AV_NOPTS_VALUE)
-          ts += pVideoState->get_ic()->start_time;
-        pVideoState->stream_seek(ts, 0, 0);
+        ts = frac * p_video_state->get_ic()->duration;
+        if (p_video_state->get_ic()->start_time != AV_NOPTS_VALUE)
+          ts += p_video_state->get_ic()->start_time;
+        p_video_state->stream_seek(ts, 0, 0);
       }
       break;
     case SDL_WINDOWEVENT:
       switch (event.window.event) {
       case SDL_WINDOWEVENT_RESIZED:
-        screen_width = width = event.window.data1;
-        screen_height = height = event.window.data2;
-        if (vis_texture) {
-          SDL_DestroyTexture(vis_texture);
-          vis_texture = NULL;
-        }
+        p_player->SetSize(event.window.data1, event.window.data2);
       case SDL_WINDOWEVENT_EXPOSED:
-        force_refresh = 1;
+        p_player->set_force_refresh(true);
       }
       break;
     case SDL_QUIT:
     case FF_QUIT_EVENT:
-      destroy();
+      delete p_player;
       exit(0); // need to exit here to avoid joinable exception
       break;
     default:
@@ -886,60 +871,57 @@ void FfmpegSdlAvPlayback::init_and_event_loop() {
   }
 }
 
-int FfmpegSdlAvPlayback::init_and_start_display_loop() {
+int FfmpegSdlAvPlayback::InitializeAndStartDisplayLoop() {
   std::mutex mtx;
   std::condition_variable cv;
-  bool initialized = false;
+  bool is_initialized = false;
 
-  // TODO(fraudies): Check for the case when the thread can't be initialized and
-  // return appropriate error (change method signature)
-  display_tid = new (std::nothrow) std::thread([this, &initialized, &cv] {
-    InitSdl();
-    initialized = true;
-    cv.notify_all();
+  p_display_thread_id_ =
+      new (std::nothrow) std::thread([this, &is_initialized, &cv] {
+        Initialize();
+        is_initialized = true;
+        cv.notify_all();
 
-    SDL_Event event;
-    while (!stopped) {
-      refresh_loop_wait_event(&event);
-      // Add handling of resizing the window
-      switch (event.type) {
-      case SDL_WINDOWEVENT:
-        switch (event.window.event) {
-        case SDL_WINDOWEVENT_RESIZED:
-          screen_width = width = event.window.data1;
-          screen_height = height = event.window.data2;
-          if (vis_texture) {
-            SDL_DestroyTexture(vis_texture);
-            vis_texture = NULL;
+        SDL_Event event;
+        while (!is_stopped_) {
+          DisplayAndProcessEvent(&event);
+          // Add handling of resizing the window
+          switch (event.type) {
+          case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_RESIZED:
+              screen_width_ = frame_width_ = event.window.data1;
+              screen_height_ = frame_height_ = event.window.data2;
+              if (p_vis_texture_) {
+                SDL_DestroyTexture(p_vis_texture_);
+                p_vis_texture_ = NULL;
+              }
+            case SDL_WINDOWEVENT_EXPOSED:
+              force_refresh_ = 1;
+            }
+            break;
+          default:
+            break;
           }
-        case SDL_WINDOWEVENT_EXPOSED:
-          force_refresh = 1;
         }
-        break;
-      default:
-        break;
-      }
-    }
-  });
+      });
 
-  if (!display_tid) {
+  if (!p_display_thread_id_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create playback thread");
     return -1;
   }
 
   std::unique_lock<std::mutex> lck(mtx);
-  cv.wait(lck, [&initialized] { return initialized; });
-  int err = ffmpegToJavaErrNo(pVideoState->stream_start());
+  cv.wait(lck, [&is_initialized] { return is_initialized; });
+  int err = ffmpegToJavaErrNo(p_video_state_->StartStream());
   if (err)
     return err;
 
-  if (pVideoState->get_image_width()) {
-    FfmpegSdlAvPlayback::set_default_window_size(
-        pVideoState->get_image_width(), pVideoState->get_image_height(),
-        pVideoState->get_image_sample_aspect_ratio());
+  if (p_video_state_->GetFrameWidth()) {
+    FfmpegSdlAvPlayback::SetDefaultWindowSize(
+        p_video_state_->GetFrameWidth(), p_video_state_->GetFrameHeight(),
+        p_video_state_->GetFrameAspectRatio());
   }
 
   return 0;
 }
-
-void FfmpegSdlAvPlayback::stop_display_loop() { stopped = true; }

--- a/src/main/cpp/FfmpegSdlAvPlayback.h
+++ b/src/main/cpp/FfmpegSdlAvPlayback.h
@@ -160,7 +160,7 @@ private:
 
   int ReallocateTexture(SDL_Texture **texture, Uint32 new_format, int new_width,
                         int new_height, SDL_BlendMode blendmode,
-                        int init_texture);
+                        bool init_texture);
 
   // called to display each frame
   void UpdateFrame(double *remaining_time);
@@ -174,12 +174,12 @@ static void sdl_audio_callback_bridge(void *vs, Uint8 *stream, int len) {
       static_cast<FfmpegSdlAvPlayback *>(vs);
   VideoState *p_video_state = nullptr;
   pFfmpegSdlAvPlayback->GetVideoState(&p_video_state);
-  p_video_state->audio_callback(stream, len);
+  p_video_state->GetAudioCallback(stream, len);
 
   // Note, the mixer can work inplace using the same stream as src and dest, see
   // source code here
   // https://github.com/davidsiaw/SDL2/blob/c315c99d46f89ef8dbb1b4eeab0fe38ea8a8b6c5/src/audio/SDL_mixer.c
-  if (!p_video_state->get_muted() && stream)
+  if (!p_video_state->IsMuted() && stream)
     SDL_MixAudioFormat(stream, stream, AUDIO_S16SYS, len,
                        pFfmpegSdlAvPlayback->GetVolumeStep());
 }

--- a/src/main/cpp/FfmpegSdlAvPlayback.h
+++ b/src/main/cpp/FfmpegSdlAvPlayback.h
@@ -13,49 +13,69 @@ extern "C" {
 #define FF_QUIT_EVENT (SDL_USEREVENT + 2)
 
 class FfmpegSdlAvPlayback : public FfmpegAvPlayback {
+public:
+  FfmpegSdlAvPlayback(int startup_volume = SDL_MIX_MAXVOLUME);
+  ~FfmpegSdlAvPlayback();
+
+  int OpenVideo(const char *filename, AVInputFormat *iformat);
+
+  inline void GetVideoState(VideoState **pp_video_state) const {
+    *pp_video_state = p_video_state_;
+  }
+
+  inline void PauseAudio() { SDL_PauseAudioDevice(audio_dev_, 0); }
+
+  // Toggle full screen mode
+  inline void ToggleFullscreen() {
+    enabled_full_screen_ = !enabled_full_screen_;
+    SDL_SetWindowFullscreen(
+        p_window_, enabled_full_screen_ ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+  }
+
+  // Get the volume
+  inline double GetVolume() const { return audio_volume_; }
+
+  // Get the volume step in Decibel
+  int GetVolumeStep() const;
+
+  // Step the volume in decibel in the desired direction
+  void StepVolume(double stepInDecibel);
+
+  // Set the volume
+  void SetVolume(double volume);
+
+  // Initializes the SDL ecosystem and starts the display loop
+  int InitializeAndStartDisplayLoop();
+
+  // Initializes the SDL ecosystem and starts the event loop to process
+  // events from the SDL window
+  static void InitializeAndListenForEvents(FfmpegSdlAvPlayback *p_player);
+
 private:
-  SDL_Window *window;
-  SDL_Renderer *renderer;
-  SDL_AudioDeviceID audio_dev = 0;
-  int ytop, xleft;
-  int xpos;
+  SDL_Window *p_window_;
+  SDL_Renderer *p_renderer_;
+  SDL_AudioDeviceID audio_dev_ = 0;
+  int x_left_;
+  int y_top_;
+  int x_pos_;
 
-  struct SwsContext *img_convert_ctx;
+  struct SwsContext *p_img_convert_ctx_;
 
-  SDL_Texture *vis_texture;
-  SDL_Texture *vid_texture;
+  SDL_Texture *p_vis_texture_;
+  SDL_Texture *p_vid_texture_;
 
-  int last_i_start;
+  int screen_width_;
+  int screen_height_;
+  int enabled_full_screen_;
 
-  int screen_width;
-  int screen_height;
-  int is_full_screen;
+  int audio_volume_;
 
-  int audio_volume;
-
-  int64_t cursor_last_shown;
-  int cursor_hidden;
-  char *window_title;
-  SDL_RendererInfo renderer_info;
-
-  inline int compute_mod(int a, int b);
-
-  inline void fill_rectangle(int x, int y, int w, int h);
-
-  static void calculate_display_rect(SDL_Rect *rect, int scr_xleft,
-                                     int scr_ytop, int scr_width,
-                                     int scr_height, int pic_width,
-                                     int pic_height, AVRational pic_sar);
-
-  std::atomic<bool> stopped = false;
-  std::thread *display_tid = nullptr;
-
-  void InitSdl(); // This is private because it has to be called on the same
-                  // thread as the looping
-  int video_open(const char *filename);
-  void closeAudioDevice();
-  void video_image_display();
-  void stop_display_loop();
+  int64_t cursor_last_shown_time_;
+  bool is_cursor_hidden_;
+  char *p_window_title_;
+  SDL_RendererInfo renderer_info_;
+  std::atomic<bool> is_stopped_ = false;
+  std::thread *p_display_thread_id_ = nullptr;
 
   static int kDefaultWidth;
   static int kDefaultHeight;
@@ -73,70 +93,95 @@ private:
     int texture_fmt;
   };
 
+  inline void GetSize(int *p_width, int *p_height) const {
+    *p_width = frame_width_;
+    *p_height = frame_height_;
+  }
+
+  void SetSize(int width, int height);
+
+  inline void SetCursorLastShownTime(int64_t time) {
+    int64_t cursor_last_shown_time_ = time;
+  }
+
+  inline void SetIsCursorHidden(bool hidden) { is_cursor_hidden_ = hidden; }
+
+  inline bool IsCursorHidden() const { return is_cursor_hidden_; }
+
+  inline bool IsScreenSizeSet() const {
+    return screen_width_ != 0 && screen_height_ != 0;
+  }
+
+  inline static int ComputeCustomModulus(int a, int b) {
+    return a < 0 ? a % b + b : a % b;
+  }
+
+  inline void FillRectangle(int x, int y, int w, int h) {
+    SDL_Rect rect = {x, y, w, h};
+    if (w >= 0 && h >= 0) {
+      SDL_RenderFillRect(p_renderer_, &rect);
+    }
+  }
+
+  // Calculates the rectangle to display taking into account the source position
+  // and the frame width, height, and aspect ratio
+  static void CalculateRectangleForDisplay(SDL_Rect *rect, int scr_xleft,
+                                           int scr_ytop, int scr_width,
+                                           int scr_height, int frame_width,
+                                           int frame_height,
+                                           AVRational frame_aspect_ratio);
+
+  inline void StopDisplayLoop() { is_stopped_ = true; }
+
+  // Initialize the SDL ecosystem
+  void Initialize();
+
+  int OpenWindow(const char *window_name);
+  inline void CloseAudio() { SDL_CloseAudioDevice(audio_dev_); }
+
+  // helper method to DisplayVideoFrame
+  void GetAndDisplayVideoFrame();
+
+  // display the current picture, if any
+  void DisplayVideoFrame();
+
   static const TextureFormatEntry kTextureFormatMap[];
 
-public:
-  FfmpegSdlAvPlayback(int startup_volume = SDL_MIX_MAXVOLUME);
-  ~FfmpegSdlAvPlayback();
+  int UploadTexture(SDL_Texture **tex, AVFrame *frame,
+                    struct SwsContext **img_convert_ctx);
 
-  int Init(const char *filename, AVInputFormat *iformat);
+  int OpenAudio(int64_t wanted_channel_layout, int wanted_nb_channels,
+                int wanted_sample_rate, struct AudioParams *audio_hw_params);
 
-  VideoState *get_VideoState();
+  static void SetDefaultWindowSize(int width, int height, AVRational sar);
 
-  int audio_open(int64_t wanted_channel_layout, int wanted_nb_channels,
-                 int wanted_sample_rate, struct AudioParams *audio_hw_params);
+  static void GetPixelFormatAndBlendmode(int format, Uint32 *sdl_pix_fmt,
+                                         SDL_BlendMode *sdl_blendmode);
 
-  static void set_default_window_size(int width, int height, AVRational sar);
+  int ReallocateTexture(SDL_Texture **texture, Uint32 new_format, int new_width,
+                        int new_height, SDL_BlendMode blendmode,
+                        int init_texture);
 
-  void pauseAudioDevice();
-
-  /* copy samples for viewing in editor window */
-  static void update_sample_display(short *samples, int samples_size);
-
-  void toggle_full_screen();
-
-  int upload_texture(SDL_Texture **tex, AVFrame *frame,
-                     struct SwsContext **img_convert_ctx);
-
-  static void get_sdl_pix_fmt_and_blendmode(int format, Uint32 *sdl_pix_fmt,
-                                            SDL_BlendMode *sdl_blendmode);
-
-  int realloc_texture(SDL_Texture **texture, Uint32 new_format, int new_width,
-                      int new_height, SDL_BlendMode blendmode,
-                      int init_texture);
-
-  /* display the current picture, if any */
-  void video_display();
-
-  int get_audio_volume() const;
-
-  void update_volume(int sign, double step);
+  // called to display each frame
+  void UpdateFrame(double *remaining_time);
 
   // Function Called from the event loop
-  void refresh_loop_wait_event(SDL_Event *event);
-
-  /* called to display each frame */
-  void video_refresh(double *remaining_time);
-
-  void destroy();
-
-  void init_and_event_loop();
-
-  int init_and_start_display_loop();
+  void DisplayAndProcessEvent(SDL_Event *event);
 };
 
 static void sdl_audio_callback_bridge(void *vs, Uint8 *stream, int len) {
   FfmpegSdlAvPlayback *pFfmpegSdlAvPlayback =
       static_cast<FfmpegSdlAvPlayback *>(vs);
-  VideoState *pVideoState = pFfmpegSdlAvPlayback->get_VideoState();
-  pVideoState->audio_callback(stream, len);
+  VideoState *p_video_state = nullptr;
+  pFfmpegSdlAvPlayback->GetVideoState(&p_video_state);
+  p_video_state->audio_callback(stream, len);
 
   // Note, the mixer can work inplace using the same stream as src and dest, see
   // source code here
   // https://github.com/davidsiaw/SDL2/blob/c315c99d46f89ef8dbb1b4eeab0fe38ea8a8b6c5/src/audio/SDL_mixer.c
-  if (!pVideoState->get_muted() && stream)
+  if (!p_video_state->get_muted() && stream)
     SDL_MixAudioFormat(stream, stream, AUDIO_S16SYS, len,
-                       pFfmpegSdlAvPlayback->get_audio_volume());
+                       pFfmpegSdlAvPlayback->GetVolumeStep());
 }
 
 #endif FFMPEGSDLAVPLAYBACK_H_

--- a/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
+++ b/src/main/cpp/FfmpegSdlAvPlaybackPipeline.cpp
@@ -3,7 +3,7 @@
 
 FfmpegSdlAvPlaybackPipeline::FfmpegSdlAvPlaybackPipeline(
     CPipelineOptions *pOptions)
-    : CPipeline(pOptions), pSdlPlayback(nullptr) {}
+    : CPipeline(pOptions), p_sdl_playback_(nullptr) {}
 
 FfmpegSdlAvPlaybackPipeline::~FfmpegSdlAvPlaybackPipeline() {
   // Clean-up done in dispose that is called from the destructor of the
@@ -16,42 +16,42 @@ uint32_t FfmpegSdlAvPlaybackPipeline::Init(const char *input_file) {
   av_log(NULL, AV_LOG_WARNING, "Init Network\n");
   AVInputFormat *file_iformat = nullptr;
 
-  pSdlPlayback = new (std::nothrow) FfmpegSdlAvPlayback();
+  p_sdl_playback_ = new (std::nothrow) FfmpegSdlAvPlayback();
 
-  if (!pSdlPlayback) {
+  if (!p_sdl_playback_) {
     return ERROR_PIPELINE_NULL;
   }
 
-  int err = pSdlPlayback->OpenVideo(input_file, file_iformat);
+  int err = p_sdl_playback_->OpenVideo(input_file, file_iformat);
   if (err) {
-    delete pSdlPlayback;
+    delete p_sdl_playback_;
     return err;
   }
 
   // Assign the callback functions
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_UNKNOWN,
       [this] { this->UpdatePlayerState(Unknown); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_READY,
       [this] { this->UpdatePlayerState(Ready); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_PLAYING,
       [this] { this->UpdatePlayerState(Playing); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_PAUSED,
       [this] { this->UpdatePlayerState(Paused); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_STOPPED,
       [this] { this->UpdatePlayerState(Stopped); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_STALLED,
       [this] { this->UpdatePlayerState(Stalled); });
-  pSdlPlayback->SetPlayerStateCallbackFunction(
+  p_sdl_playback_->SetPlayerStateCallbackFunction(
       VideoState::PlayerStateCallback::TO_FINISHED,
       [this] { this->UpdatePlayerState(Finished); });
 
-  err = pSdlPlayback->InitializeAndStartDisplayLoop();
+  err = p_sdl_playback_->InitializeAndStartDisplayLoop();
   if (err) {
     return err;
   }
@@ -60,42 +60,42 @@ uint32_t FfmpegSdlAvPlaybackPipeline::Init(const char *input_file) {
 }
 
 void FfmpegSdlAvPlaybackPipeline::Dispose() {
-  delete pSdlPlayback;
-  pSdlPlayback = nullptr;
+  delete p_sdl_playback_;
+  p_sdl_playback_ = nullptr;
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::Play() {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  pSdlPlayback->Play();
+  p_sdl_playback_->Play();
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::Stop() {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  pSdlPlayback->Stop();
+  p_sdl_playback_->Stop();
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::Pause() {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  pSdlPlayback->TogglePauseAndStopStep();
+  p_sdl_playback_->TogglePauseAndStopStep();
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::StepForward() {
-  if (pSdlPlayback == nullptr)
+  if (p_sdl_playback_ == nullptr)
     return ERROR_PLAYBACK_NULL;
 
-  pSdlPlayback->StepToNextFrame();
+  p_sdl_playback_->StepToNextFrame();
 
   return ERROR_NONE;
 }
@@ -108,34 +108,34 @@ uint32_t FfmpegSdlAvPlaybackPipeline::Finish() {
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::Seek(double dSeekTime) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  double pos = pSdlPlayback->GetTime();
+  double pos = p_sdl_playback_->GetTime();
   if (isnan(pos))
-    pos = (double)pSdlPlayback->GetSeekTime() / AV_TIME_BASE;
+    pos = (double)p_sdl_playback_->GetSeekTime() / AV_TIME_BASE;
   double incr = dSeekTime - pos;
-  if (pSdlPlayback->GetStartTime() != AV_NOPTS_VALUE &&
-      dSeekTime < pSdlPlayback->GetStartTime() / (double)AV_TIME_BASE)
-    dSeekTime = pSdlPlayback->GetStartTime() / (double)AV_TIME_BASE;
+  if (p_sdl_playback_->GetStartTime() != AV_NOPTS_VALUE &&
+      dSeekTime < p_sdl_playback_->GetStartTime() / (double)AV_TIME_BASE)
+    dSeekTime = p_sdl_playback_->GetStartTime() / (double)AV_TIME_BASE;
 
-  pSdlPlayback->Seek((int64_t)(dSeekTime * AV_TIME_BASE),
-                            (int64_t)(incr * AV_TIME_BASE), 0);
+  p_sdl_playback_->Seek((int64_t)(dSeekTime * AV_TIME_BASE),
+                     (int64_t)(incr * AV_TIME_BASE), false);
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::GetDuration(double *pdDuration) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  *pdDuration = pSdlPlayback->GetDuration();
+  *pdDuration = p_sdl_playback_->GetDuration();
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::GetStreamTime(double *pdStreamTime) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
@@ -145,52 +145,52 @@ uint32_t FfmpegSdlAvPlaybackPipeline::GetStreamTime(double *pdStreamTime) {
   // as accurate as the audio clock  (Master))
   //*pdStreamTime = pSdlPlayback->get_master_clock();
 
-  *pdStreamTime = pSdlPlayback->GetTime();
+  *pdStreamTime = p_sdl_playback_->GetTime();
 
   return ERROR_NONE; // no error
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::GetFps(double *pdFps) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  *pdFps = pSdlPlayback->GetFrameRate();
+  *pdFps = p_sdl_playback_->GetFrameRate();
 
   return ERROR_NONE;
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::SetRate(float fRate) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  return pSdlPlayback->SetSpeed(fRate);
+  return p_sdl_playback_->SetSpeed(fRate);
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::GetRate(float *pfRate) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  *pfRate = pSdlPlayback->GetSpeed();
+  *pfRate = p_sdl_playback_->GetSpeed();
 
   return ERROR_NONE;
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::SetVolume(float fVolume) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  pSdlPlayback->SetVolume(fVolume * SDL_MIX_MAXVOLUME);
+  p_sdl_playback_->SetVolume(fVolume * SDL_MIX_MAXVOLUME);
   return ERROR_NONE;
 }
 
 uint32_t FfmpegSdlAvPlaybackPipeline::GetVolume(float *pfVolume) {
-  if (pSdlPlayback == nullptr) {
+  if (p_sdl_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  *pfVolume = pSdlPlayback->GetVolume() / (double)SDL_MIX_MAXVOLUME;
+  *pfVolume = p_sdl_playback_->GetVolume() / (double)SDL_MIX_MAXVOLUME;
   return ERROR_NONE;
 }
 

--- a/src/main/cpp/FfmpegSdlAvPlaybackPipeline.h
+++ b/src/main/cpp/FfmpegSdlAvPlaybackPipeline.h
@@ -48,7 +48,7 @@ private:
   virtual uint32_t GetImageWidth(int *iWidth) const;
   virtual uint32_t GetImageHeight(int *iHeight) const;
 
-  FfmpegSdlAvPlayback *pSdlPlayback;
+  FfmpegSdlAvPlayback *p_sdl_playback_;
 };
 
 #endif //_FFMPEG_AV_PLAYBACK_PIPELINE_H_

--- a/src/main/cpp/FfmpegSdlMediaPlayer.vcxproj
+++ b/src/main/cpp/FfmpegSdlMediaPlayer.vcxproj
@@ -73,6 +73,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>C:\Program Files\Java\jdk1.8.0_172\include\win32;C:\Program Files\Java\jdk1.8.0_172\include;C:\FFplay64\include;$(IncludePath)</IncludePath>
     <LibraryPath>C:\Program Files\Java\jdk1.8.0_172\lib;C:\FFplay64\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -80,7 +82,6 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>SDL2.lib;SDL2main.lib;jawt.lib;avutil.lib;avdevice.lib;avfilter.lib;avformat.lib;avcodec.lib;postproc.lib;swresample.lib;swscale.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/main/cpp/FfmpegSdlMediaPlayer.vcxproj.filters
+++ b/src/main/cpp/FfmpegSdlMediaPlayer.vcxproj.filters
@@ -27,9 +27,6 @@
     <ClInclude Include="org_datavyu_plugins_ffmpeg_NativeMediaPlayer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="FfmpegErrorUtils.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FfmpegSdlAvPlayback.cpp">
@@ -39,9 +36,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FfmpegSdlMediaPlayer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FfmpegErrorUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/main/cpp/FrameQueue.cpp
+++ b/src/main/cpp/FrameQueue.cpp
@@ -1,91 +1,112 @@
 #include "FrameQueue.h"
 
-void unref_item(Frame *vp) { av_frame_unref(vp->frame); }
+void unref_item(Frame *vp) { av_frame_unref(vp->p_frame_); }
 
-FrameQueue::FrameQueue(const PacketQueue *pktq, int max_size, int keep_last)
-    : rindex(0), windex(0), size(0), max_size(max_size), keep_last(keep_last),
-      rindex_shown(0), pktq(pktq) {}
+FrameQueue::FrameQueue(const PacketQueue *pktq, int max_size, bool keep_last)
+    : read_index_(0), write_index_(0), size_(0), max_size_(max_size),
+      keep_last_(keep_last), read_index_shown_(0), p_packet_queue_(pktq) {}
 
-FrameQueue *FrameQueue::create_frame_queue(const PacketQueue *pktq,
-                                           int max_size, int keep_last) {
-  FrameQueue *fq = new (std::nothrow) FrameQueue(pktq, max_size, keep_last);
+FrameQueue::~FrameQueue() {
+  for (int i = 0; i < max_size_; i++) {
+    Frame *vp = &p_frames_[i];
+    if (vp) {
+      unref_item(vp);
+      av_frame_free(&vp->p_frame_);
+    }
+  }
+  delete[] p_frames_;
+}
 
-  if (!fq) {
+int FrameQueue::CreateFrameQueue(FrameQueue **pp_frame_queue,
+                                 const PacketQueue *p_packet_queue,
+                                 int max_size, bool keep_last) {
+  *pp_frame_queue =
+      new (std::nothrow) FrameQueue(p_packet_queue, max_size, keep_last);
+
+  if (!(*pp_frame_queue)) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue object");
-    return nullptr;
+    return ENOMEM;
   }
 
-  fq->queue = new (std::nothrow) Frame[max_size](); // initialize with zeros
+  (*pp_frame_queue)->p_frames_ =
+      new (std::nothrow) Frame[max_size](); // initialize with zeros
 
-  if (!fq->queue) {
+  if (!(*pp_frame_queue)->p_frames_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to initialize frame queue");
-    return nullptr;
+    return ENOMEM;
   }
 
   for (int i = 0; i < max_size; i++) {
-    fq->queue[i].frame = av_frame_alloc();
+    (*pp_frame_queue)->p_frames_[i].p_frame_ = av_frame_alloc();
 
-    if (!fq->queue[i].frame) {
+    if (!(*pp_frame_queue)->p_frames_[i].p_frame_) {
       av_log(NULL, AV_LOG_ERROR, "Unable to create frame in queue");
-      delete fq; // will clean up any memory allocated before
-      return nullptr;
+      delete (*pp_frame_queue); // will clean up any memory allocated before
+      return ENOMEM;
     }
   }
 
-  return fq;
+  return 0;
 }
 
-void FrameQueue::signal() {
-  std::unique_lock<std::mutex> locker(mutex);
-  cond.notify_one();
+void FrameQueue::Signal() {
+  std::unique_lock<std::mutex> locker(mutex_);
+  condition_.notify_one();
   locker.unlock();
 }
 
-Frame *FrameQueue::peek_writable() {
+void FrameQueue::PeekWritable(Frame **pp_frame) {
   // waits until we have space to put a new frame
-  std::unique_lock<std::mutex> locker(mutex);
-  cond.wait(locker,
-            [&] { return size < max_size || pktq->is_abort_request(); });
-  locker.unlock();
-  return pktq->is_abort_request() ? nullptr : &queue[windex];
-}
-
-Frame *FrameQueue::peek_readable() {
-  // waits until we have a readable new frame
-  std::unique_lock<std::mutex> locker(mutex);
-  cond.wait(locker, [&] {
-    return size - rindex_shown > 0 || pktq->is_abort_request();
+  std::unique_lock<std::mutex> locker(mutex_);
+  condition_.wait(locker, [&] {
+    return size_ < max_size_ || p_packet_queue_->IsAbortRequested();
   });
   locker.unlock();
-  return pktq->is_abort_request() ? nullptr
-                                  : &queue[(rindex + rindex_shown) % max_size];
+  *pp_frame =
+      p_packet_queue_->IsAbortRequested() ? nullptr : &p_frames_[write_index_];
 }
 
-void FrameQueue::push() {
-  if (++windex == max_size)
-    windex = 0;
-  std::unique_lock<std::mutex> locker(mutex);
-  size++;
-  cond.notify_one();
+void FrameQueue::PeekReadable(Frame **pp_frame) {
+  // waits until we have a readable new frame
+  std::unique_lock<std::mutex> locker(mutex_);
+  condition_.wait(locker, [&] {
+    return size_ - read_index_shown_ > 0 || p_packet_queue_->IsAbortRequested();
+  });
+  locker.unlock();
+  *pp_frame = p_packet_queue_->IsAbortRequested()
+                  ? nullptr
+                  : &p_frames_[(read_index_ + read_index_shown_) % max_size_];
+}
+
+void FrameQueue::Push() {
+  if (++write_index_ == max_size_) {
+    write_index_ = 0;
+  }
+  std::unique_lock<std::mutex> locker(mutex_);
+  size_++;
+  condition_.notify_one();
   locker.unlock();
 }
 
-void FrameQueue::next() {
-  if (keep_last && !rindex_shown) {
-    rindex_shown = 1;
+void FrameQueue::Next() {
+  if (keep_last_ && !read_index_shown_) {
+    read_index_shown_ = 1;
     return;
   }
-  unref_item(&queue[rindex]);
-  if (++rindex == max_size)
-    rindex = 0;
-  std::unique_lock<std::mutex> locker(mutex);
-  size--;
-  cond.notify_one();
+  unref_item(&p_frames_[read_index_]);
+  if (++read_index_ == max_size_) {
+    read_index_ = 0;
+  }
+  std::unique_lock<std::mutex> locker(mutex_);
+  size_--;
+  condition_.notify_one();
   locker.unlock();
 }
 
 // return last shown position
-int64_t FrameQueue::last_pos() {
-  Frame *fp = &queue[rindex];
-  return rindex_shown && fp->serial == pktq->get_serial() ? fp->pos : -1;
+int64_t FrameQueue::GetBytePosOfLastFrame() {
+  Frame *fp = &p_frames_[read_index_];
+  return read_index_shown_ && fp->serial_ == p_packet_queue_->GetSerial()
+             ? fp->byte_pos_
+             : -1;
 }

--- a/src/main/cpp/FrameQueue.h
+++ b/src/main/cpp/FrameQueue.h
@@ -19,7 +19,7 @@ typedef struct Frame {
   int width;
   int height;
   int format;
-  AVRational sar;
+  AVRational aspect_ration;
   int uploaded;
   int flip_v;
 } Frame;

--- a/src/main/cpp/FrameQueue.h
+++ b/src/main/cpp/FrameQueue.h
@@ -11,17 +11,16 @@ extern "C" {
 
 // Common struct for handling decoded data and allocated buffers
 typedef struct Frame {
-  AVFrame *frame;
-  int serial;
-  double pts;      // presentation timestamp for the frame
-  double duration; // estimated duration of the frame
-  int64_t pos;     // byte position of the frame in the input file
-  int width;
-  int height;
-  int format;
-  AVRational aspect_ration;
-  int uploaded;
-  int flip_v;
+  AVFrame *p_frame_;
+  int serial_;
+  double pts_;       // presentation timestamp for the frame
+  double duration_;  // estimated duration of the frame
+  int64_t byte_pos_; // byte position of the frame in the input file
+  int width_;
+  int height_;
+  int format_;
+  AVRational aspect_ratio_;
+  bool is_uploaded_;
 } Frame;
 
 // Frame queue provides a container for frames that hold audio and image data
@@ -45,67 +44,70 @@ typedef struct Frame {
 // of the logic)
 //
 class FrameQueue {
-private:
-  Frame *queue; // TOOD: This might be a bit slower than the original code;
-                // check whether it matters
-  int rindex;   // read index
-  int windex;   // write index
-  int size;
-  int max_size;
-  int keep_last;
-  int rindex_shown; // read index shown
-  std::mutex mutex;
-  std::condition_variable cond;
-  const PacketQueue *pktq; // packet queue
-
-  static void unref_item(Frame *vp) { av_frame_unref(vp->frame); }
-
-  FrameQueue(const PacketQueue *pktq, int max_size,
-             int keep_last); // private because of memory management
-public:
+ public:
   // Use this method to create a new frame queue to ensure cases where memory
   // allocation fails are handled properly
-  static FrameQueue *create_frame_queue(const PacketQueue *pktq, int max_size,
-                                        int keep_last);
+  static int CreateFrameQueue(FrameQueue **pp_frame_queue,
+                              const PacketQueue *p_packet_queue, int max_size,
+                              bool keep_last);
 
-  virtual ~FrameQueue() {
-    for (int i = 0; i < max_size; i++) {
-      Frame *vp = &queue[i];
-      if (vp) {
-        unref_item(vp);
-        av_frame_free(&vp->frame);
-      }
-    }
-    delete[] queue;
+  virtual ~FrameQueue();
+
+  void Signal();
+
+  // Last shown frame
+  inline void Peek(Frame **pp_frame) {
+    *pp_frame = &p_frames_[(read_index_ + read_index_shown_) % max_size_];
   }
 
-  void signal();
-
-  inline Frame *peek() { return &queue[(rindex + rindex_shown) % max_size]; }
-
-  inline Frame *peek_next() {
-    return &queue[(rindex + rindex_shown + 1) % max_size];
+  // Next to show frame
+  inline void PeekNext(Frame **pp_frame) {
+    *pp_frame = &p_frames_[(read_index_ + read_index_shown_ + 1) % max_size_];
   }
 
-  inline Frame *peek_last() { return &queue[rindex]; }
+  // Last read index
+  inline void PeekLast(Frame **pp_frame) {
+    *pp_frame = &p_frames_[read_index_];
+  }
 
-  inline std::mutex &get_mutex() { return mutex; }
+  // Need to pass out a reference for the lock to work
+  inline std::mutex &GetMutex() { return mutex_; }
 
-  inline int get_rindex_shown() const { return rindex_shown; }
+  // True if this frame queue has shown a frame
+  inline bool HasShownFrame() const { return read_index_shown_; }
 
-  Frame *peek_writable();
+  // Peek frame pointer to write to (Push will write)
+  void PeekWritable(Frame **pp_frame);
 
-  Frame *peek_readable();
+  // Peek frame pointer to read from (Next will advance the pointer)
+  void PeekReadable(Frame **pp_frame);
 
-  void push();
+  void Push();
 
-  void next();
+  void Next();
 
   // return the number of undisplayed frames in the queue
-  inline int nb_remaining() const { return size - rindex_shown; }
+  inline int GetNumToDisplay() const { return size_ - read_index_shown_; }
 
-  // return last shown position
-  int64_t last_pos();
+  // return the byte position of the frame last shown
+  int64_t GetBytePosOfLastFrame();
+
+ private:
+  Frame *p_frames_; // container for the frames
+  int read_index_;  // read index
+  int write_index_; // write index
+  int size_;        // size in bytes
+  int max_size_;
+  bool keep_last_;
+  int read_index_shown_; // read index shown
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  const PacketQueue *p_packet_queue_; // packet queue
+
+  static void unref_item(Frame *vp) { av_frame_unref(vp->p_frame_); }
+
+  FrameQueue(const PacketQueue *pktq, int max_size,
+             bool keep_last); // private because of memory management
 };
 
 #endif FRAME_QUEUE_H_

--- a/src/main/cpp/JavaPlayerEventDispatcher.h
+++ b/src/main/cpp/JavaPlayerEventDispatcher.h
@@ -45,14 +45,14 @@ public:
   virtual bool SendPlayerStateEvent(int newState, double presentTime);
 
 private:
-  JavaVM *m_PlayerVM;
-  jobject m_PlayerInstance;
-  jlong m_MediaReference; // FIXME: Nuke this field, it's completely unused
+  JavaVM *p_player_vm_;
+  jobject player_instance_;
+  jlong media_reference_; // FIXME: Nuke this field, it's completely unused
 
-  static jmethodID m_SendWarningMethod;
+  static jmethodID send_warning_method_;
 
-  static jmethodID m_SendPlayerMediaErrorEventMethod;
-  static jmethodID m_SendPlayerStateEventMethod;
+  static jmethodID send_player_media_error_event_method_;
+  static jmethodID send_player_state_event_method_;
 
   static jobject CreateObject(JNIEnv *env, jmethodID *cid,
                               const char *class_name, const char *signature,

--- a/src/main/cpp/JniUtils.cpp
+++ b/src/main/cpp/JniUtils.cpp
@@ -25,36 +25,6 @@
 
 #include "JniUtils.h"
 
-void ThrowJavaException(JNIEnv *env, const char *type, const char *message) {
-  // First check if there's already a pending exception, if there is then do
-  // nothing also abort if we're passed a NULL env
-  if (env ? env->ExceptionCheck() : true) {
-    return;
-  }
-
-  jclass klass = NULL;
-  if (type) {
-    klass = env->FindClass(type);
-    if (!klass) {
-      // might have caused an exception
-      if (env->ExceptionOccurred()) {
-        env->ExceptionClear();
-      }
-    }
-  }
-  if (!klass) {
-    klass = env->FindClass("java/lang/Exception");
-    if (!klass) {
-      if (env->ExceptionOccurred()) {
-        env->ExceptionClear();
-      }
-      // This shouldn't happen...
-      return;
-    }
-  }
-  env->ThrowNew(klass, message);
-}
-
 JNIEnv *GetJavaEnvironment(JavaVM *jvm, jboolean &didAttach) {
   JNIEnv *env = NULL;
   didAttach = false;
@@ -67,13 +37,13 @@ JNIEnv *GetJavaEnvironment(JavaVM *jvm, jboolean &didAttach) {
   return env;
 }
 
-bool CJavaEnvironment::hasException() {
-  return (environment ? (bool)environment->ExceptionCheck() : false);
+bool CJavaEnvironment::HasException() {
+  return (p_environment ? (bool)p_environment->ExceptionCheck() : false);
 }
 
-bool CJavaEnvironment::clearException() {
-  if (environment ? environment->ExceptionCheck() : false) {
-    environment->ExceptionClear();
+bool CJavaEnvironment::ClearException() {
+  if (p_environment ? p_environment->ExceptionCheck() : false) {
+    p_environment->ExceptionClear();
     return true;
   }
   return false;
@@ -83,25 +53,25 @@ bool CJavaEnvironment::clearException() {
  * Check whether there is a pending exception and if so, log its string version
  * and return true, otherwise, i.e., if there is no exception, return false.
  */
-bool CJavaEnvironment::reportException() {
-  if (environment) {
-    jthrowable exc = environment->ExceptionOccurred();
+bool CJavaEnvironment::ReportException() {
+  if (p_environment) {
+    jthrowable exc = p_environment->ExceptionOccurred();
     if (exc) {
-      environment->ExceptionClear(); // Clear current exception
-      jclass cid = environment->FindClass("java/lang/Throwable");
-      if (!clearException()) {
+      p_environment->ExceptionClear(); // Clear current exception
+      jclass cid = p_environment->FindClass("java/lang/Throwable");
+      if (!ClearException()) {
         jmethodID mid =
-            environment->GetMethodID(cid, "toString", "()Ljava/lang/String;");
-        if (!clearException()) {
-          jstring jmsg = (jstring)environment->CallObjectMethod(exc, mid);
-          if (!clearException()) {
-            char *pmsg = (char *)environment->GetStringUTFChars(jmsg, NULL);
-            environment->ReleaseStringUTFChars(jmsg, pmsg);
+            p_environment->GetMethodID(cid, "toString", "()Ljava/lang/String;");
+        if (!ClearException()) {
+          jstring jmsg = (jstring)p_environment->CallObjectMethod(exc, mid);
+          if (!ClearException()) {
+            char *pmsg = (char *)p_environment->GetStringUTFChars(jmsg, NULL);
+            p_environment->ReleaseStringUTFChars(jmsg, pmsg);
           }
         }
-        environment->DeleteLocalRef(cid);
+        p_environment->DeleteLocalRef(cid);
       }
-      environment->DeleteLocalRef(exc);
+      p_environment->DeleteLocalRef(exc);
       return true;
     }
   }
@@ -109,23 +79,23 @@ bool CJavaEnvironment::reportException() {
 }
 
 CJavaEnvironment::CJavaEnvironment(JavaVM *jvm)
-    : attached(false), environment(NULL) {
+    : attached(false), p_environment(NULL) {
   if (jvm) {
-    environment = GetJavaEnvironment(jvm, attached);
+    p_environment = GetJavaEnvironment(jvm, attached);
   }
 }
 
 CJavaEnvironment::CJavaEnvironment(JNIEnv *env) : attached(false) {
-  environment = env;
+  p_environment = env;
 }
 
 CJavaEnvironment::~CJavaEnvironment() {
-  if (attached && environment) {
+  if (attached && p_environment) {
     JavaVM *jvm;
-    if (environment->GetJavaVM(&jvm) == JNI_OK) {
+    if (p_environment->GetJavaVM(&jvm) == JNI_OK) {
       jvm->DetachCurrentThread();
     }
   }
 }
 
-JNIEnv *CJavaEnvironment::getEnvironment() { return environment; }
+JNIEnv *CJavaEnvironment::GetEnvironment() { return p_environment; }

--- a/src/main/cpp/JniUtils.h
+++ b/src/main/cpp/JniUtils.h
@@ -37,10 +37,6 @@
 #define ptr_to_jlong(a) ((jlong)(int)(a))
 #endif
 
-// Throws an exception of the given type (class name)
-// if type is NULL, then will throw a generic Exception
-void ThrowJavaException(JNIEnv *env, const char *type, const char *message);
-
 // Gets a valid, usable JNIEnv for the current thread
 // if didAttach is true on return then you should call
 // jvm->DetachCurrentThread() when done
@@ -62,16 +58,14 @@ public:
   CJavaEnvironment(JNIEnv *); // create with an existing JNIEnv
   ~CJavaEnvironment();
 
-  JNIEnv *getEnvironment();
-  bool hasException(); // return true if an exception is raised (but do nothing
+  JNIEnv *GetEnvironment();
+  bool HasException(); // return true if an exception is raised (but do nothing
                        // with it)
-  bool clearException();  // if an exception is raised, clear it and return true
-  bool reportException(); // as above but log the exception to Logger
-  void throwException(
-      std::string message); // Throw an exception with the given message
+  bool ClearException();  // if an exception is raised, clear it and return true
+  bool ReportException(); // as above but log the exception to Logger
 
 private:
-  JNIEnv *environment;
+  JNIEnv *p_environment;
   jboolean attached;
 };
 

--- a/src/main/cpp/Media.cpp
+++ b/src/main/cpp/Media.cpp
@@ -38,7 +38,7 @@
  *
  * @param   pPipe   CPipeline object to associate with the CMedia
  */
-CMedia::CMedia(CPipeline *pPipe) { m_pPipeline = pPipe; }
+CMedia::CMedia(CPipeline *pPipe) { p_pipeline = pPipe; }
 
 /**
  * CMedia::~CMedia()
@@ -46,10 +46,10 @@ CMedia::CMedia(CPipeline *pPipe) { m_pPipeline = pPipe; }
  * Destructor
  */
 CMedia::~CMedia() {
-  if (m_pPipeline != NULL) {
-    m_pPipeline->Dispose();
-    delete m_pPipeline;
-    m_pPipeline = NULL;
+  if (p_pipeline != NULL) {
+    p_pipeline->Dispose();
+    delete p_pipeline;
+    p_pipeline = NULL;
   }
 }
 
@@ -66,7 +66,7 @@ bool CMedia::IsValid(CMedia *pMedia) {
   bool bValid = false;
 
   //***** CMedia is valid if there is a pipeline associated with the media
-  bValid = (NULL != pMedia) && (NULL != pMedia->m_pPipeline);
+  bValid = (NULL != pMedia) && (NULL != pMedia->p_pipeline);
 
   return bValid;
 }
@@ -76,4 +76,4 @@ bool CMedia::IsValid(CMedia *pMedia) {
  *
  * Returns a pPointer to the associated CPipeline object.
  */
-CPipeline *CMedia::GetPipeline() { return m_pPipeline; }
+CPipeline *CMedia::GetPipeline() { return p_pipeline; }

--- a/src/main/cpp/Media.h
+++ b/src/main/cpp/Media.h
@@ -46,10 +46,10 @@ public:
   static bool IsValid(CMedia *pMedia);
 
 protected:
-  CMedia() : m_pPipeline(NULL) {}
+  CMedia() : p_pipeline(NULL) {}
 
 protected:
-  CPipeline *m_pPipeline;
+  CPipeline *p_pipeline;
 };
 
 #endif //_MEDIA_H_

--- a/src/main/cpp/MediaPlayerTest.vcxproj
+++ b/src/main/cpp/MediaPlayerTest.vcxproj
@@ -37,6 +37,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>C:\Program Files\Java\jdk1.8.0_172\include\win32;C:\Program Files\Java\jdk1.8.0_172\include;C:\FFplay64\include;$(IncludePath)</IncludePath>
     <LibraryPath>C:\Program Files\Java\jdk1.8.0_172\lib;C:\FFplay64\lib;$(LibraryPath)</LibraryPath>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="TestClock.cpp" />
@@ -79,7 +80,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/main/cpp/MpvAvPlayback.h
+++ b/src/main/cpp/MpvAvPlayback.h
@@ -46,45 +46,45 @@ typedef mpv_event *(*MpvWaitEvent)(intptr_t, double);
 class MpvAvPlayback {
 
 private:
-  HINSTANCE _libMpvDll;
-  intptr_t _mpvHandle;
+  HINSTANCE lib_mpv_dll_;
+  intptr_t mpv_handle_;
 
   // Function pointers to mpv api functions
-  MpvCreate _mpvCreate;
-  MpvInitialize _mpvInitialize;
-  MpvCommand _mpvCommand; // Always terminate a command with NULL like so const
+  MpvCreate mpv_create_;
+  MpvInitialize mpv_initialize_;
+  MpvCommand mpv_command_; // Always terminate a command with NULL like so const
                           // char * cmd = {"seek", "10", "absolute", NULL}
   MpvCommandAsync
-      _mpvCommandAsync; // Always terminate a command with NULL like so const
+      mpv_command_async_; // Always terminate a command with NULL like so const
                         // char * cmd = {"seek", "10", "absolute", NULL}
-  MpvCommandString _mpvCommandString;
-  MpvTerminateDestroy _mpvTerminateDestroy;
-  MpvSetOption _mpvSetOption;
-  MpvSetOptionString _mpvSetOptionString;
-  MpvGetPropertystring _mpvGetPropertyString;
-  MpvGetProperty _mpvGetProperty;
-  MpvSetProperty _mpvSetProperty;
-  MpvSetPropertyAsync _mpvSetPropertyAsync;
-  MpvFree _mpvFree;
-  MpvWaitEvent _mpvWaitEvent;
+  MpvCommandString mpv_command_string_;
+  MpvTerminateDestroy mpv_terminate_destroy_;
+  MpvSetOption mpv_set_option_;
+  MpvSetOptionString mpv_set_option_string_;
+  MpvGetPropertystring mpv_get_property_string_;
+  MpvGetProperty mpv_get_property_;
+  MpvSetProperty mpv_set_property_;
+  MpvSetPropertyAsync mpv_set_property_async_;
+  MpvFree mpv_free_;
+  MpvWaitEvent mpv_wait_event_;
 
   void LoadMpvDynamic();
 
   int DoMpvCommand(const char **cmd);
   int Pause();
 
-  bool _initialPlay;
-  const char *_kContainerFpsProperty = "container-fps";
-  const char *_kWidthProperty = "width";
-  const char *_kHeightProperty = "height";
-  const char *_kDurationProperty = "duration";
-  const char *_kSpeedProperty = "speed";
-  const char *_kPauseProperty = "pause";
-  const char *_kPlaybackTimeProperty = "playback-time";
-  const char *_kAoVolumeProperty = "ao-volume";
-  const char *_kFrameBackStepCommand = "frame-back-step";
-  const char *_kFrameStepCommand = "frame-step";
-  const char *_kSeekCommand = "seek";
+  bool initial_play_;
+  const char *kContainerFpsProperty = "container-fps";
+  const char *kWidthProperty = "width";
+  const char *kHeightProperty = "height";
+  const char *kDurationProperty = "duration";
+  const char *kSpeedProperty = "speed";
+  const char *kPauseProperty = "pause";
+  const char *kPlaybackTimeProperty = "playback-time";
+  const char *kAoVolumeProperty = "ao-volume";
+  const char *kFrameBackStepCommand = "frame-back-step";
+  const char *kFrameStepCommand = "frame-step";
+  const char *kSeekCommand = "seek";
 
 public:
   MpvAvPlayback();
@@ -92,23 +92,23 @@ public:
 
   int Init(const char *filename, const intptr_t windowID);
   int Destroy();
-  void init_and_event_loop(const char *filename);
+  void InitAndEventLoop(const char *filename);
   int IsPaused(bool *isPaused);
   int Play();
   int Stop();
   int TogglePause();
   int SetRate(double newRate);
-  int GetRate(double *currentRate);
-  int GetFps(double *steamFps);
-  int GetImageWidth(int64_t *imageWidth);
-  int GetImageHeight(int64_t *imageHeight);
-  int GetDuration(double *streamDuration);
+  int GetRate(double *p_rate);
+  int GetFps(double *p_fps);
+  int GetImageWidth(int64_t *p_width);
+  int GetImageHeight(int64_t *p_height);
+  int GetDuration(double *p_duration);
   int StepBackward();
   int StepForward();
-  int SetTime(double value);
-  int GetPresentationTime(double *presentationTime);
-  int SetVolume(double pfVolume);
-  int GetVolume(double *pfVolume);
+  int SetTime(double time);
+  int GetPresentationTime(double *p_time);
+  int SetVolume(double volume);
+  int GetVolume(double *p_volume);
 };
 
 #endif MPVAVPLAYBACK_H_

--- a/src/main/cpp/MpvAvPlayback.h
+++ b/src/main/cpp/MpvAvPlayback.h
@@ -43,7 +43,7 @@ typedef mpv_event *(*MpvWaitEvent)(intptr_t, double);
  * NOTE: THe mpv error codes schema:  >= 0 Succes, < 0 error
  */
 // TODO(Reda) Much naming convention of the ffmpeg plugin and error returned
-class MpvAvPlayback : public FfmpegAvPlayback {
+class MpvAvPlayback {
 
 private:
   HINSTANCE _libMpvDll;

--- a/src/main/cpp/MpvAvPlaybackPipeline.cpp
+++ b/src/main/cpp/MpvAvPlaybackPipeline.cpp
@@ -2,15 +2,15 @@
 #include "MediaPlayerErrors.h"
 
 uint32_t MpvAvPlaybackPipeline::Init(const char *input_file) {
-  pMpvPlayback = new (std::nothrow) MpvAvPlayback();
+  p_mpv_playback_ = new (std::nothrow) MpvAvPlayback();
 
-  if (!pMpvPlayback) {
+  if (!p_mpv_playback_) {
     return ERROR_PIPELINE_NULL;
   }
 
-  int err = pMpvPlayback->Init(input_file, windowID);
+  int err = p_mpv_playback_->Init(input_file, window_id_);
   if (err) {
-    delete pMpvPlayback;
+    delete p_mpv_playback_;
     return err;
   }
 
@@ -20,23 +20,23 @@ uint32_t MpvAvPlaybackPipeline::Init(const char *input_file) {
 }
 
 void MpvAvPlaybackPipeline::Dispose() {
-  pMpvPlayback->Destroy();
-  delete pMpvPlayback;
-  pMpvPlayback = nullptr;
+  p_mpv_playback_->Destroy();
+  delete p_mpv_playback_;
+  p_mpv_playback_ = nullptr;
 }
 
-MpvAvPlaybackPipeline::MpvAvPlaybackPipeline(CPipelineOptions *pOptions,
-                                             intptr_t windowID)
-    : CPipeline(pOptions), windowID(windowID), pMpvPlayback(nullptr) {}
+MpvAvPlaybackPipeline::MpvAvPlaybackPipeline(CPipelineOptions *p_options,
+                                             intptr_t window_id)
+    : CPipeline(p_options), window_id_(window_id), p_mpv_playback_(nullptr) {}
 
 MpvAvPlaybackPipeline::~MpvAvPlaybackPipeline() {}
 
 uint32_t MpvAvPlaybackPipeline::Play() {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->Play();
+  int err = p_mpv_playback_->Play();
   if (err < 0) {
     return ERROR_FFMPEG_UNKNOWN;
   }
@@ -47,11 +47,11 @@ uint32_t MpvAvPlaybackPipeline::Play() {
 }
 
 uint32_t MpvAvPlaybackPipeline::Stop() {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->Stop();
+  int err = p_mpv_playback_->Stop();
   if (err < 0) {
     return ERROR_FFMPEG_UNKNOWN;
   }
@@ -61,16 +61,16 @@ uint32_t MpvAvPlaybackPipeline::Stop() {
 }
 
 uint32_t MpvAvPlaybackPipeline::Pause() {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
-  int err = pMpvPlayback->TogglePause();
+  int err = p_mpv_playback_->TogglePause();
   if (err < 0) {
     return ERROR_FFMPEG_UNKNOWN;
   }
 
   bool isPaused;
-  if (pMpvPlayback->IsPaused(&isPaused)) {
+  if (p_mpv_playback_->IsPaused(&isPaused)) {
     UpdatePlayerState(Paused);
   } else {
     UpdatePlayerState(Playing);
@@ -80,11 +80,11 @@ uint32_t MpvAvPlaybackPipeline::Pause() {
 }
 
 uint32_t MpvAvPlaybackPipeline::StepForward() {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->StepForward();
+  int err = p_mpv_playback_->StepForward();
   if (err < 0) {
     return err;
   }
@@ -94,11 +94,11 @@ uint32_t MpvAvPlaybackPipeline::StepForward() {
 }
 
 uint32_t MpvAvPlaybackPipeline::StepBackward() {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->StepBackward();
+  int err = p_mpv_playback_->StepBackward();
   if (err < 0) {
     return err;
   }
@@ -115,11 +115,11 @@ uint32_t MpvAvPlaybackPipeline::Finish() {
 }
 
 uint32_t MpvAvPlaybackPipeline::Seek(double dSeekTime) {
-  if (pMpvPlayback == nullptr) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->SetTime(dSeekTime);
+  int err = p_mpv_playback_->SetTime(dSeekTime);
   if (err < 0) {
     return err;
   }
@@ -127,92 +127,92 @@ uint32_t MpvAvPlaybackPipeline::Seek(double dSeekTime) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetDuration(double *pdDuration) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetDuration(double *p_duration) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
   double duration;
-  int err = pMpvPlayback->GetDuration(&duration);
+  int err = p_mpv_playback_->GetDuration(&duration);
   if (err != 0) {
     return err;
   }
 
-  *pdDuration = duration;
+  *p_duration = duration;
 
   return ERROR_NONE; // no error
 }
 
-uint32_t MpvAvPlaybackPipeline::GetStreamTime(double *pdStreamTime) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetStreamTime(double *p_time) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  double presentationTime;
-  int err = pMpvPlayback->GetPresentationTime(&presentationTime);
+  double time;
+  int err = p_mpv_playback_->GetPresentationTime(&time);
   if (err != 0) {
     return err;
   }
 
-  *pdStreamTime = presentationTime;
+  *p_time = time;
 
   return ERROR_NONE; // no error
 }
 
-uint32_t MpvAvPlaybackPipeline::GetFps(double *pdFps) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetFps(double *p_fps) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
   double fps;
-  int err = pMpvPlayback->GetFps(&fps);
+  int err = p_mpv_playback_->GetFps(&fps);
   if (err != 0) {
     return err;
   }
 
-  *pdFps = fps;
+  *p_fps = fps;
 
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetImageWidth(int *iWidth) const {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetImageWidth(int *p_width) const {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int64_t imageWidth;
-  int err = pMpvPlayback->GetImageWidth(&imageWidth);
+  int64_t width;
+  int err = p_mpv_playback_->GetImageWidth(&width);
   if (err != 0) {
     return err;
   }
 
-  *iWidth = imageWidth;
+  *p_width = width;
 
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetImageHeight(int *iHeight) const {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetImageHeight(int *p_height) const {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int64_t imageHeight;
-  int err = pMpvPlayback->GetImageHeight(&imageHeight);
+  int64_t height;
+  int err = p_mpv_playback_->GetImageHeight(&height);
   if (err != 0) {
     return err;
   }
 
-  *iHeight = imageHeight;
+  *p_height = height;
 
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::SetRate(float fRate) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::SetRate(float rate) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->SetRate((double)fRate);
+  int err = p_mpv_playback_->SetRate((double)rate);
   if (err != 0) {
     return err;
   }
@@ -220,28 +220,28 @@ uint32_t MpvAvPlaybackPipeline::SetRate(float fRate) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetRate(float *pfRate) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetRate(float *p_rate) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
   double rate;
-  int err = pMpvPlayback->GetRate(&rate);
+  int err = p_mpv_playback_->GetRate(&rate);
   if (err != 0) {
     return err;
   }
 
-  *pfRate = rate;
+  *p_rate = rate;
 
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::SetVolume(float fVolume) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::SetVolume(float volume) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
-  int err = pMpvPlayback->SetVolume((double)fVolume);
+  int err = p_mpv_playback_->SetVolume((double)volume);
   if (err < 0) {
     return err;
   }
@@ -249,34 +249,34 @@ uint32_t MpvAvPlaybackPipeline::SetVolume(float fVolume) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetVolume(float *pfVolume) {
-  if (pMpvPlayback == nullptr) {
+uint32_t MpvAvPlaybackPipeline::GetVolume(float *p_volume) {
+  if (p_mpv_playback_ == nullptr) {
     return ERROR_PLAYBACK_NULL;
   }
 
   double volume;
-  int err = pMpvPlayback->GetVolume(&volume);
+  int err = p_mpv_playback_->GetVolume(&volume);
   if (err < 0) {
     return err;
   }
 
-  *pfVolume = volume;
+  *p_volume = volume;
 
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::SetBalance(float fBalance) {
+uint32_t MpvAvPlaybackPipeline::SetBalance(float balance) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetBalance(float *pfBalance) {
+uint32_t MpvAvPlaybackPipeline::GetBalance(float *p_balance) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::SetAudioSyncDelay(long lMillis) {
+uint32_t MpvAvPlaybackPipeline::SetAudioSyncDelay(long millis) {
   return ERROR_NONE;
 }
 
-uint32_t MpvAvPlaybackPipeline::GetAudioSyncDelay(long *plMillis) {
+uint32_t MpvAvPlaybackPipeline::GetAudioSyncDelay(long *p_millis) {
   return ERROR_NONE;
 }

--- a/src/main/cpp/MpvAvPlaybackPipeline.h
+++ b/src/main/cpp/MpvAvPlaybackPipeline.h
@@ -22,7 +22,7 @@ public:
   MpvAvPlaybackPipeline(CPipelineOptions *pOptions, const intptr_t windowID);
   virtual ~MpvAvPlaybackPipeline();
 
-  intptr_t windowID;
+  intptr_t window_id_;
 
 private:
   virtual uint32_t Play();
@@ -52,7 +52,7 @@ private:
   virtual uint32_t SetAudioSyncDelay(long lMillis);
   virtual uint32_t GetAudioSyncDelay(long *plMillis);
 
-  MpvAvPlayback *pMpvPlayback;
+  MpvAvPlayback *p_mpv_playback_;
 };
 
 #endif //_MPV_AV_PLAYBACK_PIPELINE_H_

--- a/src/main/cpp/MpvErrorUtils.cpp
+++ b/src/main/cpp/MpvErrorUtils.cpp
@@ -11,7 +11,7 @@
 
 #include "MPV/client.h"
 
-int mpvToJavaErrNo(int mpvErrNo) {
+int MpvToJavaErrNo(int mpvErrNo) {
   switch (mpvErrNo) {
   case MPV_ERROR_SUCCESS:
     return ERROR_NONE;

--- a/src/main/cpp/MpvErrorUtils.h
+++ b/src/main/cpp/MpvErrorUtils.h
@@ -1,6 +1,6 @@
 #ifndef _MPV_ERROR_UTILS_H_
 #define _MPV_ERROR_UTILS_H_
 
-int mpvToJavaErrNo(int mpvErrNo);
+int MpvToJavaErrNo(int mpvErrNo);
 
 #endif // _MPV_ERROR_UTILS_H_

--- a/src/main/cpp/MpvMediaPlayer.vcxproj
+++ b/src/main/cpp/MpvMediaPlayer.vcxproj
@@ -85,6 +85,8 @@
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>C:\Program Files\Java\jdk1.8.0_172\include\win32;C:\Program Files\Java\jdk1.8.0_172\include;C:\FFplay64\include;$(IncludePath)</IncludePath>
     <LibraryPath>C:\Program Files\Java\jdk1.8.0_172\lib;C:\FFplay64\lib;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>

--- a/src/main/cpp/MpvMediaPlayer.vcxproj.filters
+++ b/src/main/cpp/MpvMediaPlayer.vcxproj.filters
@@ -14,4 +14,26 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="MpvAvPlayback.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MpvAvPlaybackPipeline.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MpvMediaPlayer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MpvAvPlayback.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MpvAvPlaybackPipeline.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="org_datavyu_plugins_ffmpeg_MpvMediaPlayer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/src/main/cpp/PacketQueue.h
+++ b/src/main/cpp/PacketQueue.h
@@ -9,75 +9,74 @@ extern "C" {
 #ifndef PACKET_QUEUE_H_
 #define PACKET_QUEUE_H_
 
-/**
- * Port of the packet queue from ffplay.c into c++
- *
- * Replaces the SDL mutex through c++ std mutex/condition variable
- */
+// Port of the packet queue from ffplay.c into c++
+//
+// Replaces the SDL mutex through c++ std mutex/condition variable
 class PacketQueue {
-private:
-  // This list maintains the next for the queue
-  typedef struct MyAVPacketList {
-    AVPacket pkt;
-    struct MyAVPacketList *next;
-    int serial;
-  } MyAVPacketList;
-
-  int abort_request;
-  int serial;
-  int nb_packets;
-
-  MyAVPacketList *first_pkt, *last_pkt;
-  int size;
-  int64_t duration;
-  int condition;
-  std::mutex mutex;
-  std::condition_variable cond;
-
-  int _put(AVPacket *pkt);
-
-public:
-  AVPacket flush_pkt; // TODO(fraudies): better use one object for all queues
+ public:
+  AVPacket
+      flush_packet_;  // TODO(fraudies): better use one object for all queues
 
   PacketQueue();
 
-  // Should we detroy the mutex and condition_variabe also ?
   virtual ~PacketQueue() {
-    flush();
-    av_packet_unref(&flush_pkt);
-    av_freep(&flush_pkt);
+    Flush();
+    av_packet_unref(&flush_packet_);
+    av_freep(&flush_packet_);
   }
 
-  void flush();
+  void Flush();
 
-  void abort();
+  void Abort();
 
-  inline int is_abort_request() const { return abort_request; }
+  inline bool IsAbortRequested() const { return is_abort_requested_; }
 
-  inline int *get_p_serial() { return &serial; }
+  inline void GetPtrSerial(int **pp_serial) { *pp_serial = &serial_; }
 
-  inline int get_serial() const { return serial; }
+  inline int GetSerial() const { return serial_; }
 
-  inline int get_size() const { return size; }
+  inline int GetSize() const { return size_; }
 
-  inline int get_nb_packets() const { return nb_packets; }
+  inline int getNumberOfPackets() const { return num_packets_; }
 
-  inline int64_t get_duration() const { return duration; }
+  inline int64_t GetDuration() const { return duration_; }
 
-  void start();
+  void Start();
 
-  int put(AVPacket *pkt);
+  int Put(AVPacket *p_packet);  // Must remain a pointer to cleanup package
 
-  int put_null_packet(int stream_index);
+  int PutNullPacket(int stream_index);
 
-  int put_flush_packet();
+  int PutFlushPacket();
 
-  inline bool is_flush_packet(const AVPacket &pkt) const {
-    return pkt.data == flush_pkt.data;
+  inline bool IsFlushPacket(const AVPacket &pkt) const {
+    return pkt.data == flush_packet_.data;
   }
 
   /* return < 0 if aborted, 0 if no packet and > 0 if packet.  */
-  int get(AVPacket *pkt, int block, int *serial);
+  int Get(AVPacket *pkt, int block, int *serial);
+
+private:
+  // This list maintains the next for the queue
+  typedef struct MyAVPacketList {
+    AVPacket packet_;
+    struct MyAVPacketList *p_next_;
+    int serial_;
+  } MyAVPacketList;
+
+  bool is_abort_requested_;
+  int serial_;
+  int num_packets_;
+
+  MyAVPacketList *p_first_packet_;
+  MyAVPacketList *p_last_packet_;
+  int size_;
+  int64_t duration_;
+  bool put_condition_;
+  std::mutex mutex_;
+  std::condition_variable condition_;
+
+  int _Put(AVPacket *p_packet);
 };
 
 #endif PACKET_QUEUE_H_

--- a/src/main/cpp/Pipeline.cpp
+++ b/src/main/cpp/Pipeline.cpp
@@ -27,82 +27,81 @@
 #include "JavaPlayerEventDispatcher.h"
 #include "MediaPlayerErrors.h"
 
-//*************************************************************************************************
-//********** class CPipeline
-//*************************************************************************************************
-CPipeline::CPipeline(CPipelineOptions *pOptions)
-    : m_pEventDispatcher(NULL), m_pOptions(pOptions), m_PlayerState(Unknown),
-      m_PlayerPendingState(Unknown) {}
+CPipeline::CPipeline(CPipelineOptions *p_options)
+    : p_event_dispatcher_(nullptr), p_options_(p_options), player_state_(Unknown),
+      player_pending_state_(Unknown) {}
 
 CPipeline::~CPipeline() {
-  if (NULL != m_pOptions)
-    delete m_pOptions;
+  if (nullptr != p_options_) {
+    delete p_options_;
+  }
 
   Dispose();
 
-  if (NULL != m_pEventDispatcher)
-    delete m_pEventDispatcher;
+  if (nullptr != p_event_dispatcher_) {
+    delete p_event_dispatcher_;  
+	}
 }
 
 void CPipeline::SetEventDispatcher(
     CJavaPlayerEventDispatcher *pEventDispatcher) {
-  m_pEventDispatcher = pEventDispatcher;
+  p_event_dispatcher_ = pEventDispatcher;
 }
 
 void CPipeline::Dispose() {}
 
-void CPipeline::UpdatePlayerState(PlayerState newState) {
+void CPipeline::UpdatePlayerState(PlayerState new_state) {
   PlayerState newPlayerState =
-      m_PlayerState; // If we assign the same state again
+      player_state_; // If we assign the same state again
   bool bSilent = false;
 
-  switch (m_PlayerState) {
+  switch (player_state_) {
   case Unknown:
-    if (Ready == newState) {
+    if (Ready == new_state) {
       newPlayerState = Ready;
     }
     break;
 
   case Ready:
-    if (Playing == newState) {
+    if (Playing == new_state) {
       newPlayerState = Playing;
     }
     break;
 
   case Playing:
-    if (Stalled == newState || Paused == newState || Stopped == newState ||
-        Finished == newState) {
-      newPlayerState = newState;
+    if (Stalled == new_state || Paused == new_state || Stopped == new_state ||
+        Finished == new_state) {
+      newPlayerState = new_state;
     }
     break;
 
   case Paused:
-    if (Stopped == newState || Playing == newState) {
-      newPlayerState = newState;
+    if (Stopped == new_state || Playing == new_state) {
+      newPlayerState = new_state;
     }
     break;
 
   case Stopped:
-    if (Playing == newState || Paused == newState) {
-      newPlayerState = newState;
+    if (Playing == new_state || Paused == new_state) {
+      newPlayerState = new_state;
     }
     break;
 
   case Stalled: {
-    if (Stopped == newState || Paused == newState || Playing == newState) {
-      newPlayerState = newState;
+    if (Stopped == new_state || Paused == new_state || Playing == new_state) {
+      newPlayerState = new_state;
     }
     break;
   }
 
   case Finished:
-    if (Playing == newState) {
+    if (Playing == new_state) {
       // We can go from Finished to Playing only when seek happens (or repeat)
       // This state change should be silent.
       newPlayerState = Playing;
       bSilent = true;
     }
-    if (Stopped == newState) {
+    if (Stopped == new_state) {
       newPlayerState = Stopped;
     }
 
@@ -116,20 +115,20 @@ void CPipeline::UpdatePlayerState(PlayerState newState) {
   SetPlayerState(newPlayerState, bSilent);
 }
 
-void CPipeline::SetPlayerState(PlayerState newPlayerState, bool bSilent) {
+void CPipeline::SetPlayerState(PlayerState new_state, bool silent) {
 
   // Determine if we need to send an event out
-  bool updateState = newPlayerState != m_PlayerState;
+  bool updateState = new_state != player_state_;
   if (updateState) {
-    if (NULL != m_pEventDispatcher && !bSilent) {
-      m_PlayerState = newPlayerState;
+    if (nullptr != p_event_dispatcher_ && !silent) {
+      player_state_ = new_state;
 
-      if (!m_pEventDispatcher->SendPlayerStateEvent(newPlayerState, 0)) {
-        m_pEventDispatcher->SendPlayerMediaErrorEvent(
+      if (!p_event_dispatcher_->SendPlayerStateEvent(new_state, 0)) {
+        p_event_dispatcher_->SendPlayerMediaErrorEvent(
             ERROR_JNI_SEND_PLAYER_STATE_EVENT);
       }
     } else {
-      m_PlayerState = newPlayerState;
+      player_state_ = new_state;
     }
   }
 }

--- a/src/main/cpp/Pipeline.h
+++ b/src/main/cpp/Pipeline.h
@@ -34,11 +34,9 @@
 class CMedia;
 class CJavaPlayerEventDispatcher;
 
-/**
- * class CPipeline
- *
- * Underlying object that interfaces the JNI layer to the actual media engine
- */
+// class CPipeline
+//
+// Underlying object that interfaces the JNI layer to the actual media engine
 class CPipeline {
 public:
   enum PlayerState {
@@ -52,11 +50,10 @@ public:
     Error = 7
   };
 
-public:
-  CPipeline(CPipelineOptions *pOptions = NULL);
+  CPipeline(CPipelineOptions *p_options = NULL);
   virtual ~CPipeline();
 
-  void SetEventDispatcher(CJavaPlayerEventDispatcher *pEventDispatcher);
+  void SetEventDispatcher(CJavaPlayerEventDispatcher *p_event_dispatcher);
 
   virtual uint32_t Init(const char *filename) = 0;
   virtual void Dispose();
@@ -89,14 +86,14 @@ public:
   virtual uint32_t GetAudioSyncDelay(long *plMillis) = 0;
 
 protected:
-  CJavaPlayerEventDispatcher *m_pEventDispatcher;
-  CPipelineOptions *m_pOptions;
-  PlayerState m_PlayerState;
-  PlayerState m_PlayerPendingState; // This is necessary to get from stalled
-                                    // into the next correct state
+  CJavaPlayerEventDispatcher *p_event_dispatcher_;
+  CPipelineOptions *p_options_;
+  PlayerState player_state_;
+  PlayerState player_pending_state_; // This is necessary to get from stalled
+                                     // into the next correct state
 
-  void UpdatePlayerState(PlayerState newState);
-  void SetPlayerState(PlayerState newPlayerState, bool bSilent);
+  void UpdatePlayerState(PlayerState new_state);
+  void SetPlayerState(PlayerState new_state, bool silent);
 };
 
 #endif //_PIPELINE_H_

--- a/src/main/cpp/PipelineData.h
+++ b/src/main/cpp/PipelineData.h
@@ -9,7 +9,7 @@
 
 class CPipelineData : public CPipeline {
 public:
-  CPipelineData(CPipelineOptions *pOptions = NULL);
+  CPipelineData(CPipelineOptions *p_options = NULL);
   virtual ~CPipelineData();
 
   virtual uint32_t Init(const char *filename) = 0;
@@ -21,32 +21,32 @@ public:
   virtual uint32_t StepForward() = 0;
   virtual uint32_t Finish() = 0;
 
-  virtual uint32_t Seek(double dSeekTime) = 0;
+  virtual uint32_t Seek(double seek_time) = 0;
 
-  virtual uint32_t GetDuration(double *pdDuration) = 0;
-  virtual uint32_t GetStreamTime(double *pdStreamTime) = 0;
-  virtual uint32_t GetFps(double *pdFps) = 0;
+  virtual uint32_t GetDuration(double *p_duration) = 0;
+  virtual uint32_t GetStreamTime(double *p_stream_time) = 0;
+  virtual uint32_t GetFps(double *p_fps) = 0;
 
-  virtual uint32_t SetRate(float fRate) = 0;
-  virtual uint32_t GetRate(float *pfRate) = 0;
+  virtual uint32_t SetRate(float rate) = 0;
+  virtual uint32_t GetRate(float *p_rate) = 0;
 
-  virtual uint32_t SetVolume(float fVolume) = 0;
-  virtual uint32_t GetVolume(float *pfVolume) = 0;
+  virtual uint32_t SetVolume(float volume) = 0;
+  virtual uint32_t GetVolume(float *p_volume) = 0;
 
-  virtual uint32_t SetBalance(float fBalance) = 0;
-  virtual uint32_t GetBalance(float *pfBalance) = 0;
+  virtual uint32_t SetBalance(float balance) = 0;
+  virtual uint32_t GetBalance(float *p_balance) = 0;
 
-  virtual uint32_t SetAudioSyncDelay(long lMillis) = 0;
-  virtual uint32_t GetAudioSyncDelay(long *plMillis) = 0;
+  virtual uint32_t SetAudioSyncDelay(long millis) = 0;
+  virtual uint32_t GetAudioSyncDelay(long *p_millis) = 0;
 
-  virtual uint32_t HasAudioData(bool *bAudioData) const = 0;
-  virtual uint32_t HasImageData(bool *bImageData) const = 0;
-  virtual uint32_t GetImageWidth(int *iWidth) const = 0;
-  virtual uint32_t GetImageHeight(int *iHeight) const = 0;
-  virtual uint32_t GetAudioFormat(AudioFormat *pAudioFormat) const = 0;
-  virtual uint32_t GetPixelFormat(PixelFormat *pPixelFormat) const = 0;
-  virtual uint32_t UpdateImageBuffer(uint8_t *pImageBuffer, const long len) = 0;
-  virtual uint32_t UpdateAudioBuffer(uint8_t *pAudioBuffer, const long len) = 0;
+  virtual uint32_t HasAudioData(bool *p_audio_data) const = 0;
+  virtual uint32_t HasImageData(bool *b_image_data) const = 0;
+  virtual uint32_t GetImageWidth(int *p_width) const = 0;
+  virtual uint32_t GetImageHeight(int *p_height) const = 0;
+  virtual uint32_t GetAudioFormat(AudioFormat *p_audio_format) const = 0;
+  virtual uint32_t GetPixelFormat(PixelFormat *p_pixel_format) const = 0;
+  virtual uint32_t UpdateImageBuffer(uint8_t *p_image_buffer, const long len) = 0;
+  virtual uint32_t UpdateAudioBuffer(uint8_t *p_audio_buffer, const long len) = 0;
 };
 
 #endif //_PIPELINEDATA_H_

--- a/src/main/cpp/PipelineOptions.h
+++ b/src/main/cpp/PipelineOptions.h
@@ -33,29 +33,26 @@
 #include "FfmpegJniUtils.h"
 
 using namespace std;
-typedef list<string> ContentTypesList;
 
 class CPipelineOptions {
 public:
-public:
-  // TODO(fraudies): Add the audio and video format here
   CPipelineOptions(AudioFormat audioFormat = AudioFormat(),
                    PixelFormat pixelFormat = PixelFormat(),
                    int audioBufferSizeInBy = 0)
-      : m_audioFormat(audioFormat), m_pixelFormat(pixelFormat),
-        m_audioBufferSizeInBy(audioBufferSizeInBy) {}
+      : audio_format_(audioFormat), pixel_format_(pixelFormat),
+        audio_buffer_size_in_by_(audioBufferSizeInBy) {}
 
   virtual ~CPipelineOptions() {}
-  inline const AudioFormat *GetAudioFormat() const { return &m_audioFormat; }
-  inline const PixelFormat *GetPixelFormat() const { return &m_pixelFormat; }
+  inline const AudioFormat *GetAudioFormat() const { return &audio_format_; }
+  inline const PixelFormat *GetPixelFormat() const { return &pixel_format_; }
   inline const int GetAudioBufferSizeInBy() const {
-    return m_audioBufferSizeInBy;
+    return audio_buffer_size_in_by_;
   }
 
 private:
-  AudioFormat m_audioFormat;
-  PixelFormat m_pixelFormat;
-  int m_audioBufferSizeInBy;
+  AudioFormat audio_format_;
+  PixelFormat pixel_format_;
+  int audio_buffer_size_in_by_;
 };
 
 #endif //_PIPELINE_OPTIONS_H_

--- a/src/main/cpp/Singleton.h
+++ b/src/main/cpp/Singleton.h
@@ -31,27 +31,27 @@
 
 template <class T> class Singleton {
 public:
-  Singleton() { _instance = NULL; }
+  Singleton() { p_instance_ = NULL; }
 
   ~Singleton() {
-    if (_instance)
-      delete _instance;
+    if (p_instance_)
+      delete p_instance_;
   }
 
   uint32_t GetInstance(T **pInstance) {
     uint32_t uErrorCode = ERROR_NONE;
 
-    if (NULL == _instance)
-      uErrorCode = T::CreateInstance(&_instance);
+    if (NULL == p_instance_)
+      uErrorCode = T::CreateInstance(&p_instance_);
 
     if (ERROR_NONE == uErrorCode)
-      *pInstance = _instance;
+      *pInstance = p_instance_;
 
     return uErrorCode;
   }
 
 private:
-  T *_instance;
+  T *p_instance_;
 };
 
 #endif // _SINGLETON_H_

--- a/src/main/cpp/TestClock.cpp
+++ b/src/main/cpp/TestClock.cpp
@@ -10,7 +10,7 @@
 TEST(ClockTest, CreateAndDeleteClockTest) {
   int serial = 0;
   Clock clock(&serial);
-  ASSERT_EQ(clock.get_serial(), -1.0);
+  ASSERT_EQ(clock.GetSerial(), -1.0);
 }
 
 TEST(ClockTest, SetGetTimeTest) {
@@ -19,14 +19,14 @@ TEST(ClockTest, SetGetTimeTest) {
   Clock clock(&serial);
 
   // Set different serial should return NAN
-  clock.set_time(1.0, 2);
-  ASSERT_TRUE(isnan(clock.get_time()));
+  clock.SetTime(1.0, 2);
+  ASSERT_TRUE(isnan(clock.GetTime()));
 
   // Set clock with same serial and get time
   double time = av_gettime_relative() / MICRO;
-  clock.set_time(time, serial);
+  clock.SetTime(time, serial);
   // ASSERT LESS THAN
-  ASSERT_LT(fabs(clock.get_time() - time),
+  ASSERT_LT(fabs(clock.GetTime() - time),
             std::numeric_limits<float>::epsilon());
 
   // Wait for 100 msec
@@ -36,6 +36,6 @@ TEST(ClockTest, SetGetTimeTest) {
 
   // ASSERT LESS THAN, the expired time does not matter, only the setTime
   // changes the clock's time
-  ASSERT_LT(fabs(clock.get_time() - time),
+  ASSERT_LT(fabs(clock.GetTime() - time),
             std::numeric_limits<float>::epsilon());
 }

--- a/src/main/cpp/TestFrameQueue.cpp
+++ b/src/main/cpp/TestFrameQueue.cpp
@@ -10,31 +10,32 @@
 
 TEST(FrameQueueTest, CreateDeleteFrameQueueTest) {
   PacketQueue packetQueue;
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue, SAMPLE_QUEUE_SIZE, true);
   delete frameQueue;
 }
 
 TEST(FrameQueueTest, SingleReadWRite) {
-
   // Initialize and start the packet queue
   PacketQueue packetQueue;
-  packetQueue.start();
+  packetQueue.Start();
 
   // Initialize the frame queue
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue, SAMPLE_QUEUE_SIZE, true);
 
   // Write
-  Frame *pWriteable = frameQueue->peek_writable();
+  Frame *pWriteable = nullptr;
+  frameQueue->PeekWritable(&pWriteable);
   ASSERT_NE(pWriteable, nullptr);
-  pWriteable->pos = 123;
-  frameQueue->push();
+  pWriteable->byte_pos_ = 123;
+  frameQueue->Push();
 
   // Read
-  Frame *pReadable = frameQueue->peek_readable();
+  Frame *pReadable = nullptr;
+  frameQueue->PeekReadable(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, pWriteable->pos);
+  ASSERT_EQ(pReadable->byte_pos_, pWriteable->byte_pos_);
 
   delete frameQueue;
 }
@@ -44,60 +45,65 @@ TEST(FrameQueueTest, StatusFrameTest) {
 
   // Initialize and start the packet queue
   PacketQueue packetQueue;
-  packetQueue.start();
+  packetQueue.Start();
 
   // Initialize the frame queue
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue, SAMPLE_QUEUE_SIZE,
+                               true);
 
   // Test the intial status of the frame queue
-  ASSERT_EQ(frameQueue->nb_remaining(), 0);
-  ASSERT_EQ(frameQueue->last_pos(), -1); // nothing was shown yet => -1
+  ASSERT_EQ(frameQueue->GetNumToDisplay(), 0);
+  ASSERT_EQ(frameQueue->GetBytePosOfLastFrame(),
+            -1); // nothing was shown yet => -1
 
   // Push two frames
-  frameQueue->push();
-  frameQueue->push();
+  frameQueue->Push();
+  frameQueue->Push();
 
   // Test the status of the frame queue
-  ASSERT_EQ(frameQueue->nb_remaining(), 2);
-  ASSERT_EQ(frameQueue->last_pos(), -1); // nothing was shown yet => -1
+  ASSERT_EQ(frameQueue->GetNumToDisplay(), 2);
+  ASSERT_EQ(frameQueue->GetBytePosOfLastFrame(),
+            -1); // nothing was shown yet => -1
 
   // Read one frame
-  frameQueue->next();
-  ASSERT_EQ(frameQueue->nb_remaining(), 1);
-  ASSERT_EQ(frameQueue->last_pos(), -1); // serials don't match
+  frameQueue->Next();
+  ASSERT_EQ(frameQueue->GetNumToDisplay(), 1);
+  ASSERT_EQ(frameQueue->GetBytePosOfLastFrame(), -1); // serials don't match
 
   delete frameQueue;
 }
 
 TEST(FrameQueueTest, MultiThreadReadWriteTest) {
-
   // Initialize and start the packet queue
   PacketQueue packetQueue;
-  packetQueue.start();
+  packetQueue.Start();
 
   // Initialize the frame queue with smaller size to test for
   // blocking/unblocking
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, VIDEO_PICTURE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue,
+                               VIDEO_PICTURE_QUEUE_SIZE, true);
 
   // Write some frames
   std::thread writer([&frameQueue] {
     for (int writes = 0; writes < 10; writes++) {
-      Frame *pWritable = frameQueue->peek_writable();
+      Frame *pWritable = nullptr;
+      frameQueue->PeekWritable(&pWritable);
       ASSERT_NE(pWritable, nullptr);
-      pWritable->pos = writes;
-      frameQueue->push();
+      pWritable->byte_pos_ = writes;
+      frameQueue->Push();
     }
   });
 
   // Read some frames (blocking) and check the pos field
   std::thread reader([&frameQueue] {
     for (int reads = 0; reads < 10; reads++) {
-      Frame *pReadable = frameQueue->peek_readable();
+      Frame *pReadable = nullptr;
+      frameQueue->PeekReadable(&pReadable);
       ASSERT_NE(pReadable, nullptr);
-      frameQueue->next();
-      ASSERT_EQ(pReadable->pos, reads);
+      frameQueue->Next();
+      ASSERT_EQ(pReadable->byte_pos_, reads);
     }
   });
 
@@ -108,74 +114,78 @@ TEST(FrameQueueTest, MultiThreadReadWriteTest) {
 }
 
 TEST(FrameQueueTest, SignalFrameQueueTest) {
-
   // Intialize and start the packet queue
   PacketQueue packetQueue;
-  packetQueue.start();
+  packetQueue.Start();
 
   // Initialize the frame queue
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue, SAMPLE_QUEUE_SIZE,
+                               true);
 
   // Read packet but blocked
-  std::thread reader(
-      [&frameQueue] { ASSERT_EQ(nullptr, frameQueue->peek_readable()); });
+  std::thread reader([&frameQueue] {
+    Frame *p_frame = nullptr;
+    frameQueue->PeekReadable(&p_frame);
+    ASSERT_EQ(nullptr, p_frame);
+  });
 
-  packetQueue.abort(); // sets abort in the packet queue
+  packetQueue.Abort(); // sets abort in the packet queue
   frameQueue
-      ->signal(); // picks up abort from the packet queue and returns nullptr
+      ->Signal(); // picks up abort from the packet queue and returns nullptr
   reader.join();
 
   delete frameQueue;
 }
 
 TEST(FrameQueueTest, PeekLastNextFrameTest) {
-
   // Initialize and start the packet queue
   PacketQueue packetQueue;
-  packetQueue.start();
+  packetQueue.Start();
 
   // Initialize the frame queue
-  FrameQueue *frameQueue =
-      FrameQueue::create_frame_queue(&packetQueue, SAMPLE_QUEUE_SIZE, 1);
+  FrameQueue *frameQueue = nullptr;
+  FrameQueue::CreateFrameQueue(&frameQueue, &packetQueue, SAMPLE_QUEUE_SIZE,
+                               true);
 
   // Write frames with pos 1, 2, 3, 4
   for (int writes = 1; writes <= 4; ++writes) {
-    Frame *pWritable = frameQueue->peek_writable();
+    Frame *pWritable = nullptr;
+    frameQueue->PeekWritable(&pWritable);
     ASSERT_NE(pWritable, nullptr);
-    pWritable->pos = writes;
-    frameQueue->push();
+    pWritable->byte_pos_ = writes;
+    frameQueue->Push();
   }
 
   // Peek first, second, and last
   Frame *pReadable = nullptr;
-  pReadable = frameQueue->peek();
+  frameQueue->Peek(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 1);
-  pReadable = frameQueue->peek_next();
+  ASSERT_EQ(pReadable->byte_pos_, 1);
+  frameQueue->PeekNext(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 2);
-  pReadable = frameQueue->peek_last();
+  ASSERT_EQ(pReadable->byte_pos_, 2);
+  frameQueue->PeekLast(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 1);
+  ASSERT_EQ(pReadable->byte_pos_, 1);
 
   // Consume one frames
-  frameQueue->next();
-  pReadable = frameQueue->peek();
+  frameQueue->Next();
+  frameQueue->Peek(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 2);
-  pReadable = frameQueue->peek_last();
+  ASSERT_EQ(pReadable->byte_pos_, 2);
+  frameQueue->PeekLast(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 1);
+  ASSERT_EQ(pReadable->byte_pos_, 1);
 
   // Consume two frames
-  frameQueue->next();
-  pReadable = frameQueue->peek();
+  frameQueue->Next();
+  frameQueue->Peek(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 3);
-  pReadable = frameQueue->peek_last();
+  ASSERT_EQ(pReadable->byte_pos_, 3);
+  frameQueue->PeekLast(&pReadable);
   ASSERT_NE(pReadable, nullptr);
-  ASSERT_EQ(pReadable->pos, 2);
+  ASSERT_EQ(pReadable->byte_pos_, 2);
 
   delete frameQueue;
 }

--- a/src/main/cpp/TestPacketQueue.cpp
+++ b/src/main/cpp/TestPacketQueue.cpp
@@ -10,17 +10,17 @@ extern "C" {
 
 TEST(PacketQueueTest, CreateDeletePacketTest) {
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush();
+  packetQueue.Start();
+  packetQueue.Flush();
 }
 
 TEST(PacketQueueTest, FlushPacketQueueTest) {
   // Prepare the queue
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush(); // flushes all packets
+  packetQueue.Start();
+  packetQueue.Flush(); // flushes all packets
   AVPacket getPkt;
-  ASSERT_EQ(0, packetQueue.get(&getPkt, 0,
+  ASSERT_EQ(0, packetQueue.Get(&getPkt, 0,
                                nullptr)); // non-blocking get of empty queue
 }
 
@@ -34,10 +34,10 @@ TEST(PacketQueueTest, PutGetPacketTest) {
   putPkt.data = &dummy;
   // Create, start the packet queue and put/get
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush();
-  ASSERT_EQ(0, packetQueue.put(&putPkt));
-  ASSERT_LT(0, packetQueue.get(&getPkt, 1, nullptr));
+  packetQueue.Start();
+  packetQueue.Flush();
+  ASSERT_EQ(0, packetQueue.Put(&putPkt));
+  ASSERT_LT(0, packetQueue.Get(&getPkt, 1, nullptr));
   ASSERT_EQ(getPkt.pos, putPkt.pos);
   ASSERT_EQ(*getPkt.data, *putPkt.data);
   // Note, I don't free the packets here to simplify the code
@@ -46,34 +46,34 @@ TEST(PacketQueueTest, PutGetPacketTest) {
 TEST(PacketQueueTest, PutGetFlushPacketTest) {
   AVPacket getPkt;
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush();
-  packetQueue.put_flush_packet();
-  ASSERT_LT(0, packetQueue.get(&getPkt, 1, nullptr));
-  ASSERT_TRUE(packetQueue.is_flush_packet(getPkt));
+  packetQueue.Start();
+  packetQueue.Flush();
+  packetQueue.PutFlushPacket();
+  ASSERT_LT(0, packetQueue.Get(&getPkt, 1, nullptr));
+  ASSERT_TRUE(packetQueue.IsFlushPacket(getPkt));
 }
 
 TEST(PacketQueueTest, AbortBlockReadPacketTest) {
   // Prepare the queue
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush();
+  packetQueue.Start();
+  packetQueue.Flush();
 
   // Read packet but blocked
   std::thread reader([&packetQueue] {
     AVPacket getPkt;
-    ASSERT_EQ(-1, packetQueue.get(&getPkt, 1, nullptr)); // abort returns -1
+    ASSERT_EQ(-1, packetQueue.Get(&getPkt, 1, nullptr)); // abort returns -1
   });
 
-  packetQueue.abort();
+  packetQueue.Abort();
   reader.join();
 }
 
 TEST(PacketQueueTest, MultiThreadPutGetPacketTest) {
   // Prepare the queue
   PacketQueue packetQueue;
-  packetQueue.start();
-  packetQueue.flush();
+  packetQueue.Start();
+  packetQueue.Flush();
 
   // Write some packets
   std::thread writer([&packetQueue] {
@@ -81,7 +81,7 @@ TEST(PacketQueueTest, MultiThreadPutGetPacketTest) {
       AVPacket putPkt;
       av_init_packet(&putPkt);
       putPkt.pos = writes;
-      packetQueue.put(&putPkt);
+      packetQueue.Put(&putPkt);
     }
   });
 
@@ -89,7 +89,7 @@ TEST(PacketQueueTest, MultiThreadPutGetPacketTest) {
   std::thread reader([&packetQueue] {
     AVPacket getPkt;
     for (int reads = 0; reads < 10; reads++) {
-      ASSERT_LT(0, packetQueue.get(&getPkt, 1, nullptr));
+      ASSERT_LT(0, packetQueue.Get(&getPkt, 1, nullptr));
       ASSERT_EQ(getPkt.pos, reads);
     }
   });

--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -27,39 +27,41 @@ int VideoState::kAudioDiffAvgNum = 20; // int
 int VideoState::kVideoPictureQueueSize = 3; // int
 int VideoState::kSampleQueueSize = 9;       // int
 
-int VideoState::stream_component_open(int stream_index) {
+int VideoState::OpenStreamComponent(int stream_index) {
   AVCodecContext *avctx;
   AVCodec *codec;
-  const char *forced_codec_name = NULL;
-  AVDictionary *opts = NULL;
-  AVDictionaryEntry *t = NULL;
+  const char *forced_codec_name = nullptr;
+  AVDictionary *opts = nullptr;
+  AVDictionaryEntry *t = nullptr;
   int sample_rate, nb_channels;
   int64_t channel_layout;
   int ret = 0;
 
-  AVDictionary *codec_opts = NULL;
+  AVDictionary *codec_opts = nullptr;
 
-  if (stream_index < 0 || stream_index >= ic->nb_streams)
+  if (stream_index < 0 || stream_index >= p_format_context->nb_streams) {
     return -1;
+  }
 
-  avctx = avcodec_alloc_context3(NULL);
-  if (!avctx)
+  avctx = avcodec_alloc_context3(nullptr);
+  if (!avctx) {
     return AVERROR(ENOMEM);
+  }
 
-  ret =
-      avcodec_parameters_to_context(avctx, ic->streams[stream_index]->codecpar);
+  ret = avcodec_parameters_to_context(
+      avctx, p_format_context->streams[stream_index]->codecpar);
   if (ret < 0)
     goto fail;
-  avctx->pkt_timebase = ic->streams[stream_index]->time_base;
+  avctx->pkt_timebase = p_format_context->streams[stream_index]->time_base;
 
   codec = avcodec_find_decoder(avctx->codec_id);
 
   switch (avctx->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
-    last_audio_stream = stream_index;
+    last_audio_stream_ = stream_index;
     break;
   case AVMEDIA_TYPE_VIDEO:
-    last_video_stream = stream_index;
+    last_video_stream_ = stream_index;
     break;
   }
 
@@ -69,13 +71,20 @@ int VideoState::stream_component_open(int stream_index) {
     avctx->flags2 |= AV_CODEC_FLAG2_FAST;
   }
 
-  opts = filter_codec_opts(codec_opts, avctx->codec_id, ic,
-                           ic->streams[stream_index], codec);
-  if (!av_dict_get(opts, "threads", NULL, 0))
+  ret = GetFilterCodecOptions(opts, *codec_opts, avctx->codec_id,
+                              p_format_context,
+                              p_format_context->streams[stream_index], codec);
+  if (ret) {
+    goto fail;
+  }
+
+  if (!av_dict_get(opts, "threads", NULL, 0)) {
     av_dict_set(&opts, "threads", "auto", 0);
+  }
   if (avctx->codec_type == AVMEDIA_TYPE_VIDEO ||
-      avctx->codec_type == AVMEDIA_TYPE_AUDIO)
+      avctx->codec_type == AVMEDIA_TYPE_AUDIO) {
     av_dict_set(&opts, "refcounted_frames", "1", 0);
+  }
   if ((ret = avcodec_open2(avctx, codec, &opts)) < 0) {
     goto fail;
   }
@@ -85,8 +94,9 @@ int VideoState::stream_component_open(int stream_index) {
     goto fail;
   }
 
-  eof = 0;
-  ic->streams[stream_index]->discard = AVDISCARD_DEFAULT;
+  end_of_file_ = false;
+  p_format_context->streams[stream_index]->discard = AVDISCARD_DEFAULT;
+
   switch (avctx->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
 
@@ -94,66 +104,72 @@ int VideoState::stream_component_open(int stream_index) {
     nb_channels = avctx->channels;
     channel_layout = avctx->channel_layout;
 
-    /* prepare audio output */
-    if (!audio_open_callback)
+    // prepare audio output
+    if (!audio_open_callback) {
       goto fail;
+    }
 
     if ((ret = audio_open_callback(channel_layout, nb_channels, sample_rate,
-                                   &audio_tgt) < 0))
+                                   &audio_params_target_) < 0)) {
       goto fail;
-    audio_hw_buf_size = ret;
-    audio_src = audio_tgt;
-    audio_buf_size = 0;
-    audio_buf_index = 0;
-
-    /* init averaging filter */
-    audio_diff_avg_coef = exp(log(0.01) / kAudioDiffAvgNum);
-    audio_diff_avg_count = 0;
-    /* since we do not have a precise anough audio FIFO fullness,
-    we correct audio sync only if larger than this threshold */
-    audio_diff_threshold =
-        (double)(audio_hw_buf_size) / audio_tgt.bytes_per_sec;
-
-    audio_stream = stream_index;
-    audio_st = ic->streams[stream_index];
-    pAuddec = new Decoder(avctx, pAudioq, &continue_read_thread);
-    if ((ic->iformat->flags &
-         (AVFMT_NOBINSEARCH | AVFMT_NOGENSEARCH | AVFMT_NO_BYTE_SEEK)) &&
-        !ic->iformat->read_seek) {
-      pAuddec->set_start_pts(audio_st->start_time);
-      pAuddec->set_start_pts_tb(audio_st->time_base);
     }
-    if ((ret = pAuddec->start([this] { audio_thread(); })) < 0)
+    audio_hw_buffer_size_ = ret;
+    audio_parms_source_ = audio_params_target_;
+    audio_buffer_size_ = 0;
+    audio_buffer_index_ = 0;
+
+    // initialize the averaging filter
+    audio_diff_avg_coef_ = exp(log(0.01) / kAudioDiffAvgNum);
+    audio_diff_avg_count_ = 0;
+
+    // Since we do not have a precise enough audio FIFO fullness,
+    // we correct audio sync only if larger than this threshold
+    audio_diff_threshold_ =
+        (double)(audio_hw_buffer_size_) / audio_params_target_.bytes_per_sec;
+
+    audio_stream_index_ = stream_index;
+    p_audio_stream_ = p_format_context->streams[stream_index];
+    p_audio_decoder_ =
+        new Decoder(avctx, p_audio_packet_queue_, &continue_read_thread_);
+    if ((p_format_context->iformat->flags &
+         (AVFMT_NOBINSEARCH | AVFMT_NOGENSEARCH | AVFMT_NO_BYTE_SEEK)) &&
+        !p_format_context->iformat->read_seek) {
+      p_audio_decoder_->set_start_pts(p_audio_stream_->start_time);
+      p_audio_decoder_->set_start_pts_tb(p_audio_stream_->time_base);
+    }
+    if ((ret = p_audio_decoder_->start([this] { DecodeAudioPacketsToFrames(); })) < 0)
       goto out;
     if (pause_audio_device_callback)
       pause_audio_device_callback();
     break;
   case AVMEDIA_TYPE_VIDEO:
-    image_width = avctx->width;
-    image_height = avctx->height;
-    image_sample_aspect_ratio = avctx->sample_aspect_ratio;
+    frame_width_ = avctx->width;
+    frame_height_ = avctx->height;
+    frame_aspect_ratio_ = avctx->sample_aspect_ratio;
 
     // TODO(fraudies): Alignment for the source does not seem to be necessary,
     // but test with more res avcodec_align_dimensions(avctx, &avctx->width,
     // &avctx->height);
 
-    video_stream = stream_index;
-    video_st = ic->streams[stream_index];
+    image_stream_index_ = stream_index;
+    p_image_stream_ = p_format_context->streams[stream_index];
 
     // Calculate the Frame rate (FPS) of the video stream
-    if (video_st) {
-      AVRational f = av_guess_frame_rate(ic, video_st, NULL);
-      AVRational rational = video_st->avg_frame_rate;
+    if (p_image_stream_) {
+      AVRational f =
+          av_guess_frame_rate(p_format_context, p_image_stream_, NULL);
+      AVRational rational = p_image_stream_->avg_frame_rate;
       if (rational.den == rational.num == 0)
-        rational = video_st->r_frame_rate;
+        rational = p_image_stream_->r_frame_rate;
 
-      fps = rational.num / rational.den;
+      frame_rate_ = rational.num / rational.den;
     }
 
-    pViddec = new Decoder(avctx, pVideoq, &continue_read_thread);
-    if ((ret = pViddec->start([this] { video_thread(); })) < 0)
+    p_frame_decoder_ =
+        new Decoder(avctx, p_image_packet_queue_, &continue_read_thread_);
+    if ((ret = p_frame_decoder_->start([this] { DecodeImagePacketsToFrames(); })) < 0)
       goto out;
-    queue_attachments_req = 1;
+    queue_attachments_request_ = true;
     break;
   default:
     break;
@@ -168,31 +184,32 @@ out:
   return ret;
 }
 
-int VideoState::get_video_frame(AVFrame *frame) {
+int VideoState::GetImageFrame(AVFrame *frame) {
   int got_picture;
 
-  if ((got_picture = pViddec->decode_frame(frame)) < 0)
+  if ((got_picture = p_frame_decoder_->decode_frame(frame)) < 0)
     return -1;
 
   if (got_picture) {
     double time = frame->pts != AV_NOPTS_VALUE
-                      ? av_q2d(video_st->time_base) * frame->pts
+                      ? av_q2d(p_image_stream_->time_base) * frame->pts
                       : NAN;
 
     frame->sample_aspect_ratio =
-        av_guess_sample_aspect_ratio(ic, video_st, frame);
+        av_guess_sample_aspect_ratio(p_format_context, p_image_stream_, frame);
 
-    if (get_master_sync_type() != AV_SYNC_VIDEO_MASTER) {
+    if (GetMasterSyncType() != AV_SYNC_VIDEO_MASTER) {
       if (frame->pts != AV_NOPTS_VALUE) {
         double diff = time - get_master_clock()->get_time();
 
         av_log(NULL, AV_LOG_TRACE, "diff=%f time=%f np=%d\n", diff, time,
-               pVideoq->get_nb_packets());
+               p_image_packet_queue_->get_nb_packets());
 
         if (!isnan(diff) && fabs(diff) < kAvNoSyncThreshold && diff < 0 &&
-            pViddec->get_pkt_serial() == pVidclk->get_serial() &&
-            pVideoq->get_nb_packets()) {
-          frame_drops_early++;
+            p_frame_decoder_->get_pkt_serial() ==
+                p_image_clock_->get_serial() &&
+            p_image_packet_queue_->get_nb_packets()) {
+          num_frame_drops_early_++;
           av_frame_unref(frame);
           got_picture = 0;
         }
@@ -203,105 +220,108 @@ int VideoState::get_video_frame(AVFrame *frame) {
   return got_picture;
 }
 
-int VideoState::queue_picture(AVFrame *src_frame, double pts, double duration,
-                              int64_t pos, int serial) {
-  Frame *vp;
+int VideoState::QueueImage(AVFrame *image_frame, double pts, double duration,
+                           int64_t pos, int serial) {
+  Frame *frame = nullptr;
 
-  if (!(vp = pPictq->peek_writable()))
+  if (!(frame = p_image_frame_queue_->peek_writable())) {
     return -1;
+  }
 
-  vp->sar = src_frame->sample_aspect_ratio;
-  vp->uploaded = 0;
+  frame->aspect_ration = image_frame->sample_aspect_ratio;
+  frame->uploaded = 0;
 
-  vp->width = src_frame->width;
-  vp->height = src_frame->height;
-  vp->format = src_frame->format;
+  frame->width = image_frame->width;
+  frame->height = image_frame->height;
+  frame->format = image_frame->format;
 
-  vp->pts = pts;
-  vp->duration = duration;
-  vp->pos = pos;
-  vp->serial = serial;
+  frame->pts = pts;
+  frame->duration = duration;
+  frame->pos = pos;
+  frame->serial = serial;
 
-  av_frame_move_ref(vp->frame, src_frame);
-  pPictq->push();
+  av_frame_move_ref(frame->frame, image_frame);
+  p_image_frame_queue_->push();
   return 0;
 }
 
-void VideoState::stream_component_close(int stream_index) {
+void VideoState::CloseStreamComponent(int stream_index) {
   AVCodecParameters *codecpar;
 
-  if (stream_index < 0 || stream_index >= ic->nb_streams)
+  if (stream_index < 0 || stream_index >= p_format_context->nb_streams)
     return;
-  codecpar = ic->streams[stream_index]->codecpar;
+  codecpar = p_format_context->streams[stream_index]->codecpar;
 
   switch (codecpar->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
-    pAuddec->abort(pSampq);
-    delete pAuddec;
+    p_audio_decoder_->abort(p_audio_frame_queue_);
+    delete p_audio_decoder_;
     swr_free(&swr_ctx);
-    av_freep(&audio_buf1);
-    audio_buf1_size = 0;
-    audio_buf = NULL;
+    av_freep(&p_audio_buffer1_);
+    audio_buffer1_size_ = 0;
+    p_audio_buffer_ = nullptr;
     break;
   case AVMEDIA_TYPE_VIDEO:
-    pViddec->abort(pPictq);
-    delete pViddec;
+    p_frame_decoder_->abort(p_image_frame_queue_);
+    delete p_frame_decoder_;
     break;
   default:
     break;
   }
 
-  ic->streams[stream_index]->discard = AVDISCARD_ALL;
+  p_format_context->streams[stream_index]->discard = AVDISCARD_ALL;
   switch (codecpar->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
-    audio_st = NULL;
-    audio_stream = -1;
+    p_audio_stream_ = nullptr;
+    audio_stream_index_ = -1;
     break;
   case AVMEDIA_TYPE_VIDEO:
-    video_st = NULL;
-    video_stream = -1;
+    p_image_stream_ = nullptr;
+    image_stream_index_ = -1;
     break;
   default:
     break;
   }
 }
 
-int VideoState::stream_has_enough_packets(AVStream *st, int stream_id,
-                                          PacketQueue *queue) {
-  return stream_id < 0 || queue->is_abort_request() ||
-         (st->disposition & AV_DISPOSITION_ATTACHED_PIC) ||
-         queue->get_nb_packets() > kMinFrames &&
-             (!queue->get_duration() ||
-              av_q2d(st->time_base) * queue->get_duration() > 1.0);
+bool VideoState::StreamHasEnoughPackets(const AVStream &stream, int stream_id,
+                                        const PacketQueue &packet_queue) {
+  return stream_id < 0 || packet_queue.is_abort_request() ||
+         (stream.disposition & AV_DISPOSITION_ATTACHED_PIC) ||
+         packet_queue.get_nb_packets() > kMinFrames &&
+             (!packet_queue.get_duration() ||
+              av_q2d(stream.time_base) * packet_queue.get_duration() > 1.0);
 }
 
-/* Ported from cmdutils */
-int VideoState::check_stream_specifier(AVFormatContext *s, AVStream *st,
-                                       const char *spec) {
-  int ret = avformat_match_stream_specifier(s, st, spec);
-  if (ret < 0)
-    av_log(s, AV_LOG_ERROR, "Invalid stream specifier: %s.\n", spec);
+int VideoState::CheckStreamSpecifier(AVFormatContext *p_format_context,
+                                     AVStream *p_stream,
+                                     const char *specifier) {
+  int ret =
+      avformat_match_stream_specifier(p_format_context, p_stream, specifier);
+  if (ret < 0) {
+    av_log(p_format_context, AV_LOG_ERROR, "Invalid stream specifier: %s.\n",
+           specifier);
+  }
   return ret;
 }
 
-/* Ported from cmdutils*/
-AVDictionary *VideoState::filter_codec_opts(AVDictionary *opts,
-                                            enum AVCodecID codec_id,
-                                            AVFormatContext *s, AVStream *st,
-                                            AVCodec *codec) {
-  AVDictionary *ret = NULL;
-  AVDictionaryEntry *t = NULL;
-  int flags =
-      s->oformat ? AV_OPT_FLAG_ENCODING_PARAM : AV_OPT_FLAG_DECODING_PARAM;
+int VideoState::GetFilterCodecOptions(AVDictionary *p_opts_out,
+                                      const AVDictionary &opts_in,
+                                      AVCodecID codec_id,
+                                      AVFormatContext *p_format_context,
+                                      AVStream *p_stream, AVCodec *p_codec) {
+  AVDictionaryEntry *dict_entry = nullptr;
+  int flags = p_format_context->oformat ? AV_OPT_FLAG_ENCODING_PARAM
+                                        : AV_OPT_FLAG_DECODING_PARAM;
   char prefix = 0;
-  const AVClass *cc = avcodec_get_class();
+  const AVClass *clazz = avcodec_get_class();
 
-  if (!codec) {
-    codec = s->oformat ? avcodec_find_encoder(codec_id)
-                       : avcodec_find_decoder(codec_id);
+  if (!p_codec) {
+    p_codec = p_format_context->oformat ? avcodec_find_encoder(codec_id)
+                                        : avcodec_find_decoder(codec_id);
   }
 
-  switch (st->codecpar->codec_type) {
+  switch (p_stream->codecpar->codec_type) {
   case AVMEDIA_TYPE_VIDEO:
     prefix = 'v';
     flags |= AV_OPT_FLAG_VIDEO_PARAM;
@@ -312,79 +332,94 @@ AVDictionary *VideoState::filter_codec_opts(AVDictionary *opts,
     break;
   }
 
-  while (t = av_dict_get(opts, "", t, AV_DICT_IGNORE_SUFFIX)) {
-    char *p = strchr(t->key, ':');
+  while (dict_entry =
+             av_dict_get(&opts_in, "", dict_entry, AV_DICT_IGNORE_SUFFIX)) {
+    char *param = strchr(dict_entry->key, ':');
 
     /* check stream specification in opt name */
-    if (p) {
-      switch (check_stream_specifier(s, st, p + 1)) {
+    if (param) {
+      switch (CheckStreamSpecifier(p_format_context, p_stream, param + 1)) {
       case 1:
-        *p = 0;
+        *param = 0;
         break;
       case 0:
         continue;
       default:
-        exit(1); // TODO(fraudies): We need to handle this differently
+        av_log(NULL, AV_LOG_ERROR, "Undefined stream specifier");
+        return AVERROR_INVALIDDATA;
       }
     }
 
-    if (av_opt_find(&cc, t->key, NULL, flags, AV_OPT_SEARCH_FAKE_OBJ) ||
-        !codec ||
-        (codec->priv_class && av_opt_find(&codec->priv_class, t->key, NULL,
-                                          flags, AV_OPT_SEARCH_FAKE_OBJ))) {
-      av_dict_set(&ret, t->key, t->value, 0);
-    } else if (t->key[0] == prefix && av_opt_find(&cc, t->key + 1, NULL, flags,
-                                                  AV_OPT_SEARCH_FAKE_OBJ)) {
-      av_dict_set(&ret, t->key + 1, t->value, 0);
+    if (av_opt_find(&clazz, dict_entry->key, NULL, flags,
+                    AV_OPT_SEARCH_FAKE_OBJ) ||
+        !p_codec ||
+        (p_codec->priv_class &&
+         av_opt_find(&p_codec->priv_class, dict_entry->key, NULL, flags,
+                     AV_OPT_SEARCH_FAKE_OBJ))) {
+      av_dict_set(&p_opts_out, dict_entry->key, dict_entry->value, 0);
+    } else if (dict_entry->key[0] == prefix &&
+               av_opt_find(&clazz, dict_entry->key + 1, NULL, flags,
+                           AV_OPT_SEARCH_FAKE_OBJ)) {
+      av_dict_set(&p_opts_out, dict_entry->key + 1, dict_entry->value, 0);
     }
 
-    if (p) {
-      *p = ':';
+    if (param) {
+      *param = ':';
     }
   }
-  return ret;
+
+  return 0; // No error
 }
 
-AVDictionary **
-VideoState::setup_find_stream_info_opts(AVFormatContext *s,
-                                        AVDictionary *codec_opts) {
-  AVDictionary **opts;
-  if (!s->nb_streams) {
-    return NULL;
+int VideoState::SetupStreamOptions(AVDictionary ***opts,
+                                   AVFormatContext *p_frame_context,
+                                   AVDictionary *codec_opts) {
+  int err = 0;
+
+  if (!p_frame_context->nb_streams) {
+    return 0; // nothing to allocate here
   }
-  opts = (AVDictionary **)av_mallocz_array(s->nb_streams, sizeof(*opts));
-  if (!opts) {
+  *opts = (AVDictionary **)av_mallocz_array(p_frame_context->nb_streams,
+                                            sizeof(**opts));
+  if (!(*opts)) {
     av_log(NULL, AV_LOG_ERROR, "Could not alloc memory for stream options.\n");
-    return NULL;
+    return AVERROR(ENOMEM);
   }
-  for (int i = 0; i < s->nb_streams; i++) {
-    opts[i] = filter_codec_opts(codec_opts, s->streams[i]->codecpar->codec_id,
-                                s, s->streams[i], NULL);
+  for (int i = 0; i < p_frame_context->nb_streams; i++) {
+    // TODO: Handle error here
+    err = GetFilterCodecOptions((*opts)[i], *codec_opts,
+                                p_frame_context->streams[i]->codecpar->codec_id,
+                                p_frame_context, p_frame_context->streams[i],
+                                NULL);
+    if (err) {
+      return err;
+    }
   }
-  return opts;
+  return 0; // no error
 }
 
-int VideoState::synchronize_audio(int nb_samples) {
+int VideoState::SynchronizeAudio(int nb_samples) {
   int wanted_nb_samples = nb_samples;
 
   /* if not master, then we try to remove or add samples to correct the clock */
-  if (get_master_sync_type() != AV_SYNC_AUDIO_MASTER) {
+  if (GetMasterSyncType() != AV_SYNC_AUDIO_MASTER) {
     double diff, avg_diff;
     int min_nb_samples, max_nb_samples;
 
-    diff = pAudclk->get_time() - get_master_clock()->get_time();
+    diff = p_audio_clock_->get_time() - get_master_clock()->get_time();
 
     if (!isnan(diff) && fabs(diff) < kAvNoSyncThreshold) {
-      audio_diff_cum = diff + audio_diff_avg_coef * audio_diff_cum;
-      if (audio_diff_avg_count < kAudioDiffAvgNum) {
+      audio_diff_cum_ = diff + audio_diff_avg_coef_ * audio_diff_cum_;
+      if (audio_diff_avg_count_ < kAudioDiffAvgNum) {
         /* not enough measures to have a correct estimate */
-        audio_diff_avg_count++;
+        audio_diff_avg_count_++;
       } else {
         /* estimate the A-V difference */
-        avg_diff = audio_diff_cum * (1.0 - audio_diff_avg_coef);
+        avg_diff = audio_diff_cum_ * (1.0 - audio_diff_avg_coef_);
 
-        if (fabs(avg_diff) >= audio_diff_threshold) {
-          wanted_nb_samples = nb_samples + (int)(diff * audio_src.freq);
+        if (fabs(avg_diff) >= audio_diff_threshold_) {
+          wanted_nb_samples =
+              nb_samples + (int)(diff * audio_parms_source_.freq);
           min_nb_samples =
               ((nb_samples * (100 - kSampleCorrectionMaxPercent) / 100));
           max_nb_samples =
@@ -394,33 +429,33 @@ int VideoState::synchronize_audio(int nb_samples) {
         }
         av_log(NULL, AV_LOG_TRACE,
                "diff=%f adiff=%f sample_diff=%d apts=%0.3f %f\n", diff,
-               avg_diff, wanted_nb_samples - nb_samples, audio_pts,
-               audio_diff_threshold);
+               avg_diff, wanted_nb_samples - nb_samples, audio_pts_,
+               audio_diff_threshold_);
       }
     } else {
       /* too big difference : may be initial PTS errors, so reset A-V filter */
-      audio_diff_avg_count = 0;
-      audio_diff_cum = 0;
+      audio_diff_avg_count_ = 0;
+      audio_diff_cum_ = 0;
     }
   }
   return wanted_nb_samples;
 }
 
-int VideoState::audio_decode_frame() {
+int VideoState::DecodeAudioFrame() {
   int data_size, resampled_data_size;
   int64_t dec_channel_layout;
   int wanted_nb_samples;
   Frame *af;
   double original_sample_rate;
 
-  if (paused)
+  if (is_paused_)
     return -1;
 
   do {
-    if (!(af = pSampq->peek_readable()))
+    if (!(af = p_audio_frame_queue_->peek_readable()))
       return -1;
-    pSampq->next();
-  } while (af->serial != pAudioq->get_serial());
+    p_audio_frame_queue_->next();
+  } while (af->serial != p_audio_packet_queue_->get_serial());
 
   data_size = av_samples_get_buffer_size(
       NULL, af->frame->channels, af->frame->nb_samples,
@@ -432,19 +467,20 @@ int VideoState::audio_decode_frame() {
            av_get_channel_layout_nb_channels(af->frame->channel_layout))
           ? af->frame->channel_layout
           : av_get_default_channel_layout(af->frame->channels);
-  wanted_nb_samples = synchronize_audio(af->frame->nb_samples);
+  wanted_nb_samples = SynchronizeAudio(af->frame->nb_samples);
 
   original_sample_rate = af->frame->sample_rate;
   // Change the sample_rate by the playback rate
-  af->frame->sample_rate *= rate_value;
+  af->frame->sample_rate *= current_speed_;
 
-  if (af->frame->format != audio_src.fmt ||
-      dec_channel_layout != audio_src.channel_layout ||
-      af->frame->sample_rate != audio_src.freq ||
+  if (af->frame->format != audio_parms_source_.fmt ||
+      dec_channel_layout != audio_parms_source_.channel_layout ||
+      af->frame->sample_rate != audio_parms_source_.freq ||
       (wanted_nb_samples != af->frame->nb_samples && !swr_ctx)) {
     swr_free(&swr_ctx);
-    swr_ctx = swr_alloc_set_opts(NULL, audio_tgt.channel_layout, audio_tgt.fmt,
-                                 audio_tgt.freq, dec_channel_layout,
+    swr_ctx = swr_alloc_set_opts(NULL, audio_params_target_.channel_layout,
+                                 audio_params_target_.fmt,
+                                 audio_params_target_.freq, dec_channel_layout,
                                  static_cast<AVSampleFormat>(af->frame->format),
                                  af->frame->sample_rate, 0, NULL);
     if (!swr_ctx || swr_init(swr_ctx) < 0) {
@@ -454,25 +490,27 @@ int VideoState::audio_decode_frame() {
              af->frame->sample_rate,
              av_get_sample_fmt_name(
                  static_cast<AVSampleFormat>(af->frame->format)),
-             af->frame->channels, audio_tgt.freq,
-             av_get_sample_fmt_name(audio_tgt.fmt), audio_tgt.channels);
+             af->frame->channels, audio_params_target_.freq,
+             av_get_sample_fmt_name(audio_params_target_.fmt),
+             audio_params_target_.channels);
       swr_free(&swr_ctx);
       return -1;
     }
-    audio_src.channel_layout = dec_channel_layout;
-    audio_src.channels = af->frame->channels;
-    audio_src.freq = af->frame->sample_rate;
-    audio_src.fmt = static_cast<AVSampleFormat>(af->frame->format);
+    audio_parms_source_.channel_layout = dec_channel_layout;
+    audio_parms_source_.channels = af->frame->channels;
+    audio_parms_source_.freq = af->frame->sample_rate;
+    audio_parms_source_.fmt = static_cast<AVSampleFormat>(af->frame->format);
   }
 
   if (swr_ctx) {
     const uint8_t **in = (const uint8_t **)af->frame->extended_data;
-    uint8_t **out = &audio_buf1;
-    int out_count =
-        (int64_t)wanted_nb_samples * audio_tgt.freq / af->frame->sample_rate +
-        256;
-    int out_size = av_samples_get_buffer_size(NULL, audio_tgt.channels,
-                                              out_count, audio_tgt.fmt, 0);
+    uint8_t **out = &p_audio_buffer1_;
+    int out_count = (int64_t)wanted_nb_samples * audio_params_target_.freq /
+                        af->frame->sample_rate +
+                    256;
+    int out_size =
+        av_samples_get_buffer_size(NULL, audio_params_target_.channels,
+                                   out_count, audio_params_target_.fmt, 0);
     int len2;
     if (out_size < 0) {
       av_log(NULL, AV_LOG_ERROR, "av_samples_get_buffer_size() failed\n");
@@ -481,15 +519,16 @@ int VideoState::audio_decode_frame() {
     if (wanted_nb_samples != af->frame->nb_samples) {
       if (swr_set_compensation(swr_ctx,
                                (wanted_nb_samples - af->frame->nb_samples) *
-                                   audio_tgt.freq / af->frame->sample_rate,
-                               wanted_nb_samples * audio_tgt.freq /
+                                   audio_params_target_.freq /
+                                   af->frame->sample_rate,
+                               wanted_nb_samples * audio_params_target_.freq /
                                    af->frame->sample_rate) < 0) {
         av_log(NULL, AV_LOG_ERROR, "swr_set_compensation() failed\n");
         return -1;
       }
     }
-    av_fast_malloc(&audio_buf1, &audio_buf1_size, out_size);
-    if (!audio_buf1)
+    av_fast_malloc(&p_audio_buffer1_, &audio_buffer1_size_, out_size);
+    if (!p_audio_buffer1_)
       return AVERROR(ENOMEM);
     len2 = swr_convert(swr_ctx, out, out_count, in, af->frame->nb_samples);
     if (len2 < 0) {
@@ -501,19 +540,19 @@ int VideoState::audio_decode_frame() {
       if (swr_init(swr_ctx) < 0)
         swr_free(&swr_ctx);
     }
-    audio_buf = audio_buf1;
-    resampled_data_size =
-        len2 * audio_tgt.channels * av_get_bytes_per_sample(audio_tgt.fmt);
+    p_audio_buffer_ = p_audio_buffer1_;
+    resampled_data_size = len2 * audio_params_target_.channels *
+                          av_get_bytes_per_sample(audio_params_target_.fmt);
   } else {
-    audio_buf = af->frame->data[0];
+    p_audio_buffer_ = af->frame->data[0];
     resampled_data_size = data_size;
   }
 
   /* update the audio clock with the pts */
-  audio_pts = isnan(af->pts) ? NAN
-                             : af->pts + (double)af->frame->nb_samples /
-                                             original_sample_rate;
-  audio_serial = af->serial;
+  audio_pts_ = isnan(af->pts) ? NAN
+                              : af->pts + (double)af->frame->nb_samples /
+                                              original_sample_rate;
+  audio_serial_ = af->serial;
 
   return resampled_data_size;
 }
@@ -522,132 +561,144 @@ int VideoState::audio_decode_frame() {
 // The initialization order is correct now, but it is not garuanteed that some
 // of these might not be null; hence, we initialize this in the create function
 VideoState::VideoState(int audio_buffer_size)
-    : abort_request(0), paused(true), // TRUE
-      last_paused(0), stopped(false), queue_attachments_req(0), seek_req(0),
-      seek_flags(AVSEEK_FLAG_BACKWARD), // AV_SEEK_BACKWARD
-      seek_pos(0), seek_rel(0), read_pause_return(0), av_sync_type(0), fps(0),
-      vidclk_last_set_time(0), video_stream(0), max_frame_duration(0), eof(0),
-      video_duration(0), image_width(0), image_height(0),
-      image_sample_aspect_ratio(av_make_q(0, 0)), step(false), new_rate_req(0),
-      new_rate_value(1.0), rate_value(1.0), audio_disable(0), video_disable(0),
-      last_video_stream(0), last_audio_stream(0), filename(nullptr),
-      pAudioq(nullptr), pVideoq(nullptr), pSampq(nullptr), pPictq(nullptr),
-      pAudclk(nullptr), pVidclk(nullptr), pExtclk(nullptr), pAuddec(nullptr),
-      pViddec(nullptr), read_tid(nullptr), iformat(nullptr), ic(nullptr),
-      swr_ctx(nullptr), audio_st(nullptr), video_st(nullptr), audio_stream(0),
-      audio_pts(0.0), audio_serial(0), audio_diff_cum(0.0),
-      audio_diff_avg_coef(0.0), audio_diff_threshold(0.0),
-      audio_diff_avg_count(0), audio_hw_buf_size(0),
-      audio_buffer_size(audio_buffer_size), audio_buf(nullptr),
-      audio_buf1(nullptr), audio_buf_size(0), /* in bytes */
-      audio_buf1_size(0), audio_buf_index(0), /* in bytes */
-      audio_write_buf_size(0), muted(0), frame_drops_early(0),
-      start_time(AV_NOPTS_VALUE), max_duration(AV_NOPTS_VALUE), loop(1) {}
+    : abort_request_(false), is_paused_(true), // TRUE
+      last_is_paused_(false), is_stopped_(false),
+      queue_attachments_request_(false), seek_request_(false),
+      seek_flags_(AVSEEK_FLAG_BACKWARD), // AV_SEEK_BACKWARD
+      seek_time_(0), seek_distance_(0), sync_type_(AV_SYNC_AUDIO_MASTER),
+      frame_rate_(0), video_clock_last_set_time_(0), image_stream_index_(0),
+      max_frame_duration_(0), end_of_file_(false), duration_(0),
+      frame_width_(0), frame_height_(0), frame_aspect_ratio_(av_make_q(0, 0)),
+      is_stepping_(false), speed_request_(false), requested_speed_(1.0),
+      current_speed_(1.0), audio_disabled_(false), video_disabled_(false),
+      last_video_stream_(0), last_audio_stream_(0), filename_(nullptr),
+      p_audio_packet_queue_(nullptr), p_image_packet_queue_(nullptr),
+      p_audio_frame_queue_(nullptr), p_image_frame_queue_(nullptr),
+      p_audio_clock_(nullptr), p_image_clock_(nullptr),
+      p_external_clock_(nullptr), p_audio_decoder_(nullptr),
+      p_frame_decoder_(nullptr), p_reader_thread_(nullptr),
+      p_input_format_(nullptr), p_format_context(nullptr), swr_ctx(nullptr),
+      p_audio_stream_(nullptr), p_image_stream_(nullptr),
+      audio_stream_index_(0), audio_pts_(0.0), audio_serial_(0),
+      audio_diff_cum_(0.0), audio_diff_avg_coef_(0.0),
+      audio_diff_threshold_(0.0), audio_diff_avg_count_(0),
+      audio_hw_buffer_size_(0), audio_default_buffer_size_(audio_buffer_size),
+      p_audio_buffer_(nullptr), p_audio_buffer1_(nullptr),
+      audio_buffer_size_(0),                          /* in bytes */
+      audio_buffer1_size_(0), audio_buffer_index_(0), /* in bytes */
+      audio_write_buffer_size_(0), is_muted_(0), num_frame_drops_early_(0),
+      start_time_(AV_NOPTS_VALUE), max_duration_(AV_NOPTS_VALUE), num_loop_(1) {
+}
 
-VideoState *VideoState::create_video_state(int audio_buffer_size) {
+int VideoState::CreateVideoState(VideoState **pp_video_state,
+                                 int audio_buffer_size) {
+
   // Create the video state
-  VideoState *vs = new (std::nothrow) VideoState(audio_buffer_size);
-  if (!vs) {
+  *pp_video_state = new (std::nothrow) VideoState(audio_buffer_size);
+  if (!*pp_video_state) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create new video state");
-    return nullptr;
+    return ENOMEM;
   }
 
   // Initialize packet queues
-  vs->pAudioq = new (std::nothrow) PacketQueue();
-  if (!vs->pAudioq) {
+  (*pp_video_state)->p_audio_packet_queue_ = new (std::nothrow) PacketQueue();
+  if (!(*pp_video_state)->p_audio_packet_queue_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create packet queue for audio");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
-  vs->pVideoq = new (std::nothrow) PacketQueue();
-  if (!vs->pVideoq) {
+  (*pp_video_state)->p_image_packet_queue_ = new (std::nothrow) PacketQueue();
+  if (!(*pp_video_state)->p_image_packet_queue_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create packet queue for video");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
 
   // Handle frame queues
-  vs->pSampq = FrameQueue::create_frame_queue(vs->pAudioq, kSampleQueueSize, 1);
-  if (!vs->pSampq) {
+  (*pp_video_state)->p_audio_frame_queue_ = FrameQueue::create_frame_queue(
+      (*pp_video_state)->p_audio_packet_queue_, kSampleQueueSize, 1);
+  if (!(*pp_video_state)->p_audio_frame_queue_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for audio");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
-  vs->pPictq =
-      FrameQueue::create_frame_queue(vs->pVideoq, kVideoPictureQueueSize, 1);
-  if (!vs->pPictq) {
+  (*pp_video_state)->p_image_frame_queue_ = FrameQueue::create_frame_queue(
+      (*pp_video_state)->p_image_packet_queue_, kVideoPictureQueueSize, 1);
+  if (!(*pp_video_state)->p_image_frame_queue_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for video");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
 
   // Create clocks
-  vs->pAudclk = new (std::nothrow) Clock(vs->pAudioq->get_p_serial());
-  if (!vs->pAudclk) {
+  (*pp_video_state)->p_audio_clock_ = new (std::nothrow)
+      Clock((*pp_video_state)->p_audio_packet_queue_->get_p_serial());
+  if (!(*pp_video_state)->p_audio_clock_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create clock for audio");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
-  vs->pVidclk = new (std::nothrow) Clock(vs->pVideoq->get_p_serial());
-  if (!vs->pVidclk) {
+  (*pp_video_state)->p_image_clock_ = new (std::nothrow)
+      Clock((*pp_video_state)->p_image_packet_queue_->get_p_serial());
+  if (!(*pp_video_state)->p_image_clock_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create clock for video");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
-  vs->pExtclk = new (std::nothrow) Clock();
-  if (!vs->pExtclk) {
+  (*pp_video_state)->p_external_clock_ = new (std::nothrow) Clock();
+  if (!(*pp_video_state)->p_external_clock_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create clock for external");
-    delete vs;
-    return nullptr;
+    delete *pp_video_state;
+    return ENOMEM;
   }
 
-  return vs;
+  return 0; // no error
 }
 
 VideoState::~VideoState() {
 
   // From stream close
-  abort_request = 1;
-  if (read_tid) {
-    read_tid->join();
-    delete read_tid;
-    read_tid = nullptr;
+  abort_request_ = true;
+  if (p_reader_thread_) {
+    p_reader_thread_->join();
+    delete p_reader_thread_;
+    p_reader_thread_ = nullptr;
   }
 
-  if (audio_stream >= 0) {
-    stream_component_close(audio_stream);
+  if (audio_stream_index_ >= 0) {
+    CloseStreamComponent(audio_stream_index_);
   }
-  if (video_stream >= 0) {
-    stream_component_close(video_stream);
+  if (image_stream_index_ >= 0) {
+    CloseStreamComponent(image_stream_index_);
   }
 
-  if (ic) {
-    avformat_close_input(&ic);
+  if (p_format_context) {
+    avformat_close_input(&p_format_context);
   }
-  av_free(filename);
+  av_free(filename_);
   // End stream close
 
   // From close method
-  if (pVideoq)
-    delete (pVideoq);
-  if (pAudioq)
-    delete (pAudioq);
+  if (p_image_packet_queue_)
+    delete (p_image_packet_queue_);
+  if (p_audio_packet_queue_)
+    delete (p_audio_packet_queue_);
 
-  if (pPictq)
-    delete (pPictq);
-  if (pSampq)
-    delete (pSampq);
+  if (p_image_frame_queue_)
+    delete (p_image_frame_queue_);
+  if (p_audio_frame_queue_)
+    delete (p_audio_frame_queue_);
 
-  if (pVidclk)
-    delete (pVidclk);
-  if (pAudclk)
-    delete (pAudclk);
-  if (pExtclk)
-    delete (pExtclk);
+  if (p_image_clock_)
+    delete (p_image_clock_);
+  if (p_audio_clock_)
+    delete (p_audio_clock_);
+  if (p_external_clock_)
+    delete (p_external_clock_);
 }
 
 //* Gets the stream from the disk or the network */
-int VideoState::read_thread() {
+int VideoState::ReadPacketsToQueues() {
   int ret;
   AVPacket pkt1, *pkt = &pkt1;
   bool was_stalled = false;
@@ -655,19 +706,18 @@ int VideoState::read_thread() {
   int64_t stream_start_time;
   int pkt_in_play_range = 0;
   int64_t pkt_ts;
-
   // TODO: Need to work in TO_STOPPED state
   // Reda: added bool stopped when we trigger stop; when stopped both is stopped
   // and paused are set to 1 So each time we check for pause we need to check
   // inside the condition if it is also stopped
 
   for (;;) {
-    if (abort_request)
+    if (abort_request_)
       break;
-    if (paused != last_paused) {
-      last_paused = paused;
-      if (paused) {
-        if (stopped) {
+    if (is_paused_ != last_is_paused_) {
+      last_is_paused_ = is_paused_;
+      if (is_paused_) {
+        if (is_stopped_) {
           if (player_state_callbacks[TO_STOPPED]) {
             player_state_callbacks[TO_STOPPED]();
           }
@@ -676,17 +726,19 @@ int VideoState::read_thread() {
             player_state_callbacks[TO_PAUSED]();
           }
         }
-        read_pause_return = av_read_pause(ic);
+        // TODO(fraudies): This is used when reading from a network stream,
+        // remove?
+        av_read_pause(p_format_context);
       } else {
-        av_read_play(ic); // Start Playing a network based stream
+        av_read_play(p_format_context); // Start Playing a network based stream
         if (player_state_callbacks[TO_PLAYING]) {
           player_state_callbacks[TO_PLAYING]();
         }
       }
     }
     if (was_stalled) {
-      if (paused) {
-        if (stopped) {
+      if (is_paused_) {
+        if (is_stopped_) {
           if (player_state_callbacks[TO_STOPPED]) {
             player_state_callbacks[TO_STOPPED]();
           }
@@ -702,49 +754,52 @@ int VideoState::read_thread() {
       }
       was_stalled = false;
     }
-    if (new_rate_req) {
-      rate_value = new_rate_value;
-      new_rate_req = 0;
-      queue_attachments_req = 1;
+    if (speed_request_) {
+      current_speed_ = requested_speed_;
+      speed_request_ = false;
+      queue_attachments_request_ = true;
     }
 
-    if (seek_req) {
+    if (seek_request_) {
       if (player_state_callbacks[TO_STALLED]) {
         player_state_callbacks[TO_STALLED]();
         was_stalled = true;
       }
 
-      int64_t seek_target = seek_pos;
-      int64_t seek_min = seek_rel > 0 ? seek_target - seek_rel + 2 : INT64_MIN;
-      int64_t seek_max = seek_rel < 0 ? seek_target - seek_rel - 2 : INT64_MAX;
+      int64_t seek_target = seek_time_;
+      int64_t seek_min =
+          seek_distance_ > 0 ? seek_target - seek_distance_ + 2 : INT64_MIN;
+      int64_t seek_max =
+          seek_distance_ < 0 ? seek_target - seek_distance_ - 2 : INT64_MAX;
       // FIXME the +-2 is due to rounding being not done in the correct
       // direction in generation
       //      of the seek_pos/seek_rel variables
-      ret = avformat_seek_file(ic, -1, seek_min, seek_target, seek_max,
-                               seek_flags);
+      ret = avformat_seek_file(p_format_context, -1, seek_min, seek_target,
+                               seek_max, seek_flags_);
       if (ret < 0) {
-        av_log(NULL, AV_LOG_ERROR, "%s: error while seeking\n", ic->url);
+        av_log(NULL, AV_LOG_ERROR, "%s: error while seeking\n",
+               p_format_context->url);
       } else {
-        if (audio_stream >= 0) {
-          pAudioq->flush();
-          pAudioq->put_flush_packet();
+        if (audio_stream_index_ >= 0) {
+          p_audio_packet_queue_->flush();
+          p_audio_packet_queue_->put_flush_packet();
         }
-        if (video_stream >= 0) {
-          pVideoq->flush();
-          pVideoq->put_flush_packet();
+        if (image_stream_index_ >= 0) {
+          p_image_packet_queue_->flush();
+          p_image_packet_queue_->put_flush_packet();
         }
-        if (seek_flags & AVSEEK_FLAG_BYTE) {
-          pExtclk->set_time(
+        if (seek_flags_ & AVSEEK_FLAG_BYTE) {
+          p_external_clock_->set_time(
               NAN, 0); // 0 != -1 which will return NAN for interim time
         } else {
-          pExtclk->set_time(
+          p_external_clock_->set_time(
               seek_target / (double)AV_TIME_BASE,
               0); // 0 != -1 which will return NAN for interim time
         }
       }
-      seek_req = 0;
-      queue_attachments_req = 1;
-      eof = 0;
+      seek_request_ = false;
+      queue_attachments_request_ = true;
+      end_of_file_ = false;
       av_log(NULL, AV_LOG_INFO,
              "Seek: ext: %7.2f sec - aud : %7.2f sec - vid : %7.2f sec - Error "
              ": %7.2f sec\n",
@@ -752,7 +807,7 @@ int VideoState::read_thread() {
              get_pVidclk()->get_time(),
              fabs(get_pExtclk()->get_time() - get_pAudclk()->get_time()));
 
-      if (paused) {
+      if (is_paused_) {
         step_to_next_frame_callback(); // Assume that the step callback is set
                                        // -- otherwise fail hard here
       } else {
@@ -762,83 +817,92 @@ int VideoState::read_thread() {
         was_stalled = false;
       }
     }
-    if (queue_attachments_req) {
-      if (video_st && video_st->disposition & AV_DISPOSITION_ATTACHED_PIC) {
+    if (queue_attachments_request_) {
+      if (p_image_stream_ &&
+          p_image_stream_->disposition & AV_DISPOSITION_ATTACHED_PIC) {
         AVPacket copy = {0};
-        if ((ret = av_packet_ref(&copy, &video_st->attached_pic)) < 0)
+        if ((ret = av_packet_ref(&copy, &p_image_stream_->attached_pic)) < 0)
           goto fail;
-        pVideoq->put(&copy);
-        pVideoq->put_null_packet(video_stream);
+        p_image_packet_queue_->put(&copy);
+        p_image_packet_queue_->put_null_packet(image_stream_index_);
       }
-      queue_attachments_req = 0;
+      queue_attachments_request_ = false;
     }
 
     /* if the queues are full, no need to read more */
-    if (pAudioq->get_size() + pVideoq->get_size() > kMaxQueueSize ||
-        (stream_has_enough_packets(audio_st, audio_stream, pAudioq) &&
-         stream_has_enough_packets(video_st, video_stream, pVideoq))) {
+    if (p_audio_packet_queue_->get_size() + p_image_packet_queue_->get_size() >
+            kMaxQueueSize ||
+        (StreamHasEnoughPackets(*p_audio_stream_, audio_stream_index_,
+                                *p_audio_packet_queue_) &&
+         StreamHasEnoughPackets(*p_image_stream_, image_stream_index_,
+                                *p_image_packet_queue_))) {
       /* wait 10 ms */
       std::unique_lock<std::mutex> locker(wait_mutex);
-      continue_read_thread.wait_for(locker, std::chrono::milliseconds(10));
+      continue_read_thread_.wait_for(locker, std::chrono::milliseconds(10));
       locker.unlock();
       continue;
     }
-    if (!paused &&
-        (!audio_st || (pAuddec->is_finished() == pAudioq->get_serial() &&
-                       pSampq->nb_remaining() == 0)) &&
-        (!video_st || (pViddec->is_finished() == pVideoq->get_serial() &&
-                       pPictq->nb_remaining() == 0))) {
-      if (loop != 1 && (!loop || --loop)) {
-        stream_seek(start_time != AV_NOPTS_VALUE ? start_time : 0, 0, 0);
+    if (!is_paused_ &&
+        (!p_audio_stream_ || (p_audio_decoder_->is_finished() ==
+                                  p_audio_packet_queue_->get_serial() &&
+                              p_audio_frame_queue_->nb_remaining() == 0)) &&
+        (!p_image_stream_ || (p_frame_decoder_->is_finished() ==
+                                  p_image_packet_queue_->get_serial() &&
+                              p_image_frame_queue_->nb_remaining() == 0))) {
+      if (num_loop_ != 1 && (!num_loop_ || --num_loop_)) {
+        stream_seek(start_time_ != AV_NOPTS_VALUE ? start_time_ : 0, 0, 0);
       }
     }
-    ret = av_read_frame(ic, pkt);
+    ret = av_read_frame(p_format_context, pkt);
     if (ret < 0) {
-      if ((ret == AVERROR_EOF || avio_feof(ic->pb)) && !eof) {
-        if (video_stream >= 0) {
-          pVideoq->put_null_packet(video_stream);
+      if ((ret == AVERROR_EOF || avio_feof(p_format_context->pb)) &&
+          !end_of_file_) {
+        if (image_stream_index_ >= 0) {
+          p_image_packet_queue_->put_null_packet(image_stream_index_);
         }
-        if (audio_stream >= 0) {
-          pAudioq->put_null_packet(audio_stream);
+        if (audio_stream_index_ >= 0) {
+          p_audio_packet_queue_->put_null_packet(audio_stream_index_);
         }
-        eof = 1;
+        end_of_file_ = true;
 
         // Set the player state to finished
         if (player_state_callbacks[TO_FINISHED]) {
           player_state_callbacks[TO_FINISHED]();
         }
       }
-      if (ic->pb && ic->pb->error)
+      if (p_format_context->pb && p_format_context->pb->error)
         break;
       /* wait 10 ms */
       std::unique_lock<std::mutex> locker(wait_mutex);
-      continue_read_thread.wait_for(locker, std::chrono::milliseconds(10));
+      continue_read_thread_.wait_for(locker, std::chrono::milliseconds(10));
       locker.unlock();
       continue;
     } else {
-      eof = 0;
+      end_of_file_ = false;
       // TODO(fraudies): Set the player state from stalled to ready here (if
       // ready don't do anything)
     }
     /* check if packet is in play range specified by user, then queue, otherwise
      * discard */
-    stream_start_time = ic->streams[pkt->stream_index]->start_time;
+    stream_start_time =
+        p_format_context->streams[pkt->stream_index]->start_time;
     pkt_ts = pkt->pts == AV_NOPTS_VALUE ? pkt->dts : pkt->pts;
 
     pkt_in_play_range =
-        max_duration == AV_NOPTS_VALUE ||
+        max_duration_ == AV_NOPTS_VALUE ||
         (pkt_ts -
          (stream_start_time != AV_NOPTS_VALUE ? stream_start_time : 0)) *
-                    av_q2d(ic->streams[pkt->stream_index]->time_base) -
-                (double)(start_time != AV_NOPTS_VALUE ? start_time : 0) /
+                    av_q2d(p_format_context->streams[pkt->stream_index]
+                               ->time_base) -
+                (double)(start_time_ != AV_NOPTS_VALUE ? start_time_ : 0) /
                     1000000 <=
-            ((double)max_duration / 1000000);
+            ((double)max_duration_ / 1000000);
 
-    if (pkt->stream_index == audio_stream && pkt_in_play_range) {
-      pAudioq->put(pkt);
-    } else if (pkt->stream_index == video_stream && pkt_in_play_range &&
-               !(video_st->disposition & AV_DISPOSITION_ATTACHED_PIC)) {
-      pVideoq->put(pkt);
+    if (pkt->stream_index == audio_stream_index_ && pkt_in_play_range) {
+      p_audio_packet_queue_->put(pkt);
+    } else if (pkt->stream_index == image_stream_index_ && pkt_in_play_range &&
+               !(p_image_stream_->disposition & AV_DISPOSITION_ATTACHED_PIC)) {
+      p_image_packet_queue_->put(pkt);
     } else {
       av_packet_unref(pkt);
     }
@@ -846,8 +910,8 @@ int VideoState::read_thread() {
 
   ret = 0;
 fail:
-  if (ret != 0 && ic)
-    avformat_close_input(&ic);
+  if (ret != 0 && p_format_context)
+    avformat_close_input(&p_format_context);
 
   if (ret != 0 && destroy_callback) {
     destroy_callback();
@@ -857,7 +921,7 @@ fail:
 }
 
 /* Called when the stream is opened */
-int VideoState::audio_thread() {
+int VideoState::DecodeAudioPacketsToFrames() {
   AVFrame *frame = av_frame_alloc();
   Frame *af;
 
@@ -869,13 +933,13 @@ int VideoState::audio_thread() {
     return AVERROR(ENOMEM);
 
   do {
-    if ((got_frame = pAuddec->decode_frame(frame)) < 0)
+    if ((got_frame = p_audio_decoder_->decode_frame(frame)) < 0)
       goto the_end;
 
     if (got_frame) {
       tb = av_make_q(1, frame->sample_rate);
 
-      if (!(af = pSampq->peek_writable()))
+      if (!(af = p_audio_frame_queue_->peek_writable()))
         goto the_end;
 
       av_log(NULL, AV_LOG_TRACE, "Audio frame pts = %I64d, tb = %2.7f\n",
@@ -883,11 +947,11 @@ int VideoState::audio_thread() {
 
       af->pts = (frame->pts == AV_NOPTS_VALUE) ? NAN : frame->pts * av_q2d(tb);
       af->pos = frame->pkt_pos;
-      af->serial = pAuddec->get_pkt_serial();
+      af->serial = p_audio_decoder_->get_pkt_serial();
       af->duration = av_q2d(av_make_q(frame->nb_samples, frame->sample_rate));
 
       av_frame_move_ref(af->frame, frame);
-      pSampq->push();
+      p_audio_frame_queue_->push();
     }
   } while (ret >= 0 || ret == AVERROR(EAGAIN) || ret == AVERROR_EOF);
 the_end:
@@ -896,20 +960,21 @@ the_end:
 }
 
 /* Called when the stream is opened */
-int VideoState::video_thread() {
+int VideoState::DecodeImagePacketsToFrames() {
   AVFrame *frame = av_frame_alloc();
   double pts;
   double duration;
   int ret;
-  AVRational tb = video_st->time_base;
-  AVRational frame_rate = av_guess_frame_rate(ic, video_st, NULL);
+  AVRational tb = p_image_stream_->time_base;
+  AVRational frame_rate =
+      av_guess_frame_rate(p_format_context, p_image_stream_, NULL);
 
   if (!frame) {
     return AVERROR(ENOMEM);
   }
 
   for (;;) {
-    ret = get_video_frame(frame);
+    ret = GetImageFrame(frame);
     if (ret < 0)
       goto the_end;
     if (!ret)
@@ -922,8 +987,8 @@ int VideoState::video_thread() {
                    ? av_q2d(av_make_q(frame_rate.den, frame_rate.num))
                    : 0;
     pts = (frame->pts == AV_NOPTS_VALUE) ? NAN : frame->pts * av_q2d(tb);
-    ret = queue_picture(frame, pts, duration, frame->pkt_pos,
-                        pViddec->get_pkt_serial());
+    ret = QueueImage(frame, pts, duration, frame->pkt_pos,
+                     p_frame_decoder_->get_pkt_serial());
     av_frame_unref(frame);
 
     if (ret < 0)
@@ -935,55 +1000,55 @@ the_end:
 }
 
 /* Public Members*/
-VideoState *VideoState::stream_open(const char *filename,
-                                    AVInputFormat *iformat,
-                                    int audio_buffer_size) {
-  VideoState *is = VideoState::create_video_state(audio_buffer_size);
-  if (!is) {
-    return NULL;
+int VideoState::OpenStream(VideoState **pp_video_state, const char *filename,
+                           AVInputFormat *iformat, int audio_buffer_size) {
+  int err;
+
+  err = VideoState::CreateVideoState(pp_video_state, audio_buffer_size);
+  if (err) {
+    return err;
   }
 
-  is->filename = av_strdup(filename);
-  if (!is->filename) {
-    return NULL;
+  (*pp_video_state)->filename_ = av_strdup(filename);
+  if (!(*pp_video_state)->filename_) {
+    return ENOMEM;
   }
 
-  is->iformat = iformat;
+  (*pp_video_state)->p_input_format_ = iformat;
 
-  is->audio_serial = -1;
+  (*pp_video_state)->audio_serial_ = -1;
 
-  is->av_sync_type = AV_SYNC_AUDIO_MASTER;
-
-  return is;
+  return 0; // no error
 }
 
-int VideoState::stream_start() {
+int VideoState::StartStream() {
   int i, ret;
   int st_index[AVMEDIA_TYPE_NB];
   AVDictionaryEntry *t;
   int scan_all_pmts_set = 0;
-  AVDictionary *format_opts = NULL;
-  AVDictionary *codec_opts = NULL;
-  AVDictionary **opts;
+  AVDictionary *format_opts = nullptr;
+  AVDictionary *codec_opts = nullptr;
+  AVDictionary **opts = nullptr;
 
   memset(st_index, -1, sizeof(st_index));
-  last_video_stream = video_stream = -1;
-  last_audio_stream = audio_stream = -1;
-  eof = 0;
+  last_video_stream_ = image_stream_index_ = -1;
+  last_audio_stream_ = audio_stream_index_ = -1;
+  end_of_file_ = false;
 
-  ic = avformat_alloc_context();
-  if (!ic) {
+  p_format_context = avformat_alloc_context();
+  if (!p_format_context) {
     av_log(NULL, AV_LOG_FATAL, "Could not allocate context.\n");
     ret = AVERROR(ENOMEM);
     goto fail;
   }
-  ic->interrupt_callback.callback = decode_interrupt_cb_bridge;
-  ic->interrupt_callback.opaque = this;
+  p_format_context->interrupt_callback.callback = decode_interrupt_cb_bridge;
+  p_format_context->interrupt_callback.opaque = this;
   if (!av_dict_get(format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE)) {
     av_dict_set(&format_opts, "scan_all_pmts", "1", AV_DICT_DONT_OVERWRITE);
     scan_all_pmts_set = 1;
   }
-  ret = avformat_open_input(&ic, filename, iformat, &format_opts);
+  ret = avformat_open_input(&p_format_context, filename_, p_input_format_,
+                            &format_opts);
   if (ret < 0) {
     goto fail;
   }
@@ -997,83 +1062,93 @@ int VideoState::stream_start() {
   }
 
   if (kEnableGeneratePts) {
-    ic->flags |= AVFMT_FLAG_GENPTS;
+    p_format_context->flags |= AVFMT_FLAG_GENPTS;
   }
 
-  av_format_inject_global_side_data(ic);
+  av_format_inject_global_side_data(p_format_context);
 
   // Find the stream information
-  opts = setup_find_stream_info_opts(ic, codec_opts);
-  ret = avformat_find_stream_info(ic, opts);
-  for (i = 0; i < ic->nb_streams; i++) {
+  ret = SetupStreamOptions(&opts, p_format_context, codec_opts);
+  if (ret) {
+    // TODO(fraudies): Clean up dictionary memory
+    goto fail;
+  }
+
+  ret = avformat_find_stream_info(p_format_context, opts);
+  for (i = 0; i < p_format_context->nb_streams; i++) {
     av_dict_free(&opts[i]);
   }
   av_freep(&opts);
 
   if (ret < 0) {
     av_log(NULL, AV_LOG_WARNING, "%s: could not find codec parameters\n",
-           filename);
+           filename_);
     goto fail;
   }
 
-  if (ic->pb)
-    ic->pb->eof_reached = 0; // FIXME hack, ffplay maybe should not use
-                             // avio_feof() to test for the end
+  if (p_format_context->pb)
+    p_format_context->pb->eof_reached =
+        0; // FIXME hack, ffplay maybe should not use
+           // avio_feof() to test for the end
 
   if (kEnableSeekByBytes < 0)
-    kEnableSeekByBytes = !!(ic->iformat->flags & AVFMT_TS_DISCONT) &&
-                         strcmp("ogg", ic->iformat->name);
+    kEnableSeekByBytes =
+        !!(p_format_context->iformat->flags & AVFMT_TS_DISCONT) &&
+        strcmp("ogg", p_format_context->iformat->name);
 
-  max_frame_duration = (ic->iformat->flags & AVFMT_TS_DISCONT) ? 10.0 : 3600.0;
+  max_frame_duration_ =
+      (p_format_context->iformat->flags & AVFMT_TS_DISCONT) ? 10.0 : 3600.0;
 
   /* if seeking requested, we execute it */
-  if (start_time != AV_NOPTS_VALUE) {
+  if (start_time_ != AV_NOPTS_VALUE) {
     int64_t timestamp;
 
-    timestamp = start_time;
+    timestamp = start_time_;
     /* add the stream start time */
-    if (ic->start_time != AV_NOPTS_VALUE)
-      timestamp += ic->start_time;
-    ret = avformat_seek_file(ic, -1, INT64_MIN, timestamp, INT64_MAX, 0);
+    if (p_format_context->start_time != AV_NOPTS_VALUE)
+      timestamp += p_format_context->start_time;
+    ret = avformat_seek_file(p_format_context, -1, INT64_MIN, timestamp,
+                             INT64_MAX, 0);
     if (ret < 0) {
       av_log(NULL, AV_LOG_WARNING, "%s: could not seek to position %0.3f\n",
-             filename, (double)timestamp / AV_TIME_BASE);
+             filename_, (double)timestamp / AV_TIME_BASE);
     }
   }
 
   if (kEnableShowFormat) {
-    av_dump_format(ic, 0, filename, 0);
+    av_dump_format(p_format_context, 0, filename_, 0);
   }
 
-  for (i = 0; i < ic->nb_streams; i++) {
-    AVStream *st = ic->streams[i];
+  for (i = 0; i < p_format_context->nb_streams; i++) {
+    AVStream *st = p_format_context->streams[i];
     enum AVMediaType type = st->codecpar->codec_type;
     st->discard = AVDISCARD_ALL;
   }
 
-  if (!video_disable)
-    st_index[AVMEDIA_TYPE_VIDEO] = av_find_best_stream(
-        ic, AVMEDIA_TYPE_VIDEO, st_index[AVMEDIA_TYPE_VIDEO], -1, NULL, 0);
-  if (!audio_disable)
+  if (!video_disabled_)
+    st_index[AVMEDIA_TYPE_VIDEO] =
+        av_find_best_stream(p_format_context, AVMEDIA_TYPE_VIDEO,
+                            st_index[AVMEDIA_TYPE_VIDEO], -1, NULL, 0);
+  if (!audio_disabled_)
     st_index[AVMEDIA_TYPE_AUDIO] = av_find_best_stream(
-        ic, AVMEDIA_TYPE_AUDIO, st_index[AVMEDIA_TYPE_AUDIO],
+        p_format_context, AVMEDIA_TYPE_AUDIO, st_index[AVMEDIA_TYPE_AUDIO],
         st_index[AVMEDIA_TYPE_VIDEO], NULL, 0);
 
   /* open the streams */
   if (st_index[AVMEDIA_TYPE_AUDIO] >= 0) {
-    stream_component_open(st_index[AVMEDIA_TYPE_AUDIO]);
+    OpenStreamComponent(st_index[AVMEDIA_TYPE_AUDIO]);
   }
   // Set the video duration
-  video_duration = ic->duration / (double)AV_TIME_BASE;
+  duration_ = p_format_context->duration / (double)AV_TIME_BASE;
 
   ret = -1;
   if (st_index[AVMEDIA_TYPE_VIDEO] >= 0) {
-    ret = stream_component_open(st_index[AVMEDIA_TYPE_VIDEO]);
+    ret = OpenStreamComponent(st_index[AVMEDIA_TYPE_VIDEO]);
   }
 
-  if (video_stream < 0 && audio_stream < 0) {
+  if (image_stream_index_ < 0 && audio_stream_index_ < 0) {
     av_log(NULL, AV_LOG_FATAL,
-           "Failed to open file '%s' or configure filtergraph\n", filename);
+           "Failed to open file '%s' or configure filtergraph\n", filename_);
     ret = AVERROR_STREAM_NOT_FOUND;
     goto fail;
   }
@@ -1082,8 +1157,8 @@ int VideoState::stream_start() {
     player_state_callbacks[TO_READY]();
   }
 
-  read_tid = new (std::nothrow) std::thread([this] { read_thread(); });
-  if (!read_tid) {
+  p_reader_thread_ = new (std::nothrow) std::thread([this] { ReadPacketsToQueues(); });
+  if (!p_reader_thread_) {
     av_log(NULL, AV_LOG_FATAL, "Unable to create reader thread\n");
     ret = AVERROR(ENOMEM);
     goto fail;
@@ -1092,8 +1167,8 @@ int VideoState::stream_start() {
   return 0;
 
 fail:
-  if (ret != 0 && ic)
-    avformat_close_input(&ic);
+  if (ret != 0 && p_format_context)
+    avformat_close_input(&p_format_context);
 
   if (ret != 0 && destroy_callback) {
     destroy_callback();
@@ -1104,21 +1179,22 @@ fail:
 
 void VideoState::update_pts(double pts, int serial) {
   get_pVidclk()->set_time(pts, serial);
-  vidclk_last_set_time = av_gettime_relative() / 1000000.0;
+  video_clock_last_set_time_ = av_gettime_relative() / 1000000.0;
   // Sync external clock to video clock
   Clock::sync_slave_to_master(get_pExtclk(), get_pVidclk(), kAvNoSyncThreshold);
 }
 
 /* seek in the stream */
 void VideoState::stream_seek(int64_t pos, int64_t rel, int seek_by_bytes) {
-  if (!seek_req) {
-    seek_pos = pos;
-    seek_rel = rel;
-    seek_flags &= ~AVSEEK_FLAG_BYTE;
-    if (seek_by_bytes)
-      seek_flags |= AVSEEK_FLAG_BYTE;
-    seek_req = 1;
-    continue_read_thread.notify_one();
+  if (!seek_request_) {
+    seek_time_ = pos;
+    seek_distance_ = rel;
+    seek_flags_ &= ~AVSEEK_FLAG_BYTE;
+    if (seek_by_bytes) {
+      seek_flags_ |= AVSEEK_FLAG_BYTE;
+    }
+    seek_request_ = true;
+    continue_read_thread_.notify_one();
   }
 }
 
@@ -1140,17 +1216,17 @@ double VideoState::compute_target_delay(double delay) {
   double sync_threshold, diff = 0;
 
   /* update delay to follow master synchronisation source */
-  if (get_master_sync_type() != AV_SYNC_VIDEO_MASTER) {
+  if (GetMasterSyncType() != AV_SYNC_VIDEO_MASTER) {
     /* if video is slave, we try to correct big delays by
     duplicating or deleting a frame */
-    diff = pVidclk->get_time() - get_master_clock()->get_time();
+    diff = p_image_clock_->get_time() - get_master_clock()->get_time();
 
     /* skip or repeat frame. We take into account the
     delay to compute the threshold. I still don't know
     if it is the best guess */
     sync_threshold =
         FFMAX(kAvSyncThresholdMin, FFMIN(kAvSyncThresholdMax, delay));
-    if (!isnan(diff) && fabs(diff) < max_frame_duration) {
+    if (!isnan(diff) && fabs(diff) < max_frame_duration_) {
       if (diff <= -sync_threshold)
         delay = FFMAX(0, delay + diff);
       else if (diff >= sync_threshold && delay > kAvSyncFrameDupThreshold)
@@ -1166,14 +1242,14 @@ double VideoState::compute_target_delay(double delay) {
 }
 
 /* get the current synchronization type */
-VideoState::AvSyncType VideoState::get_master_sync_type() const {
-  if (av_sync_type == AV_SYNC_VIDEO_MASTER) {
-    if (video_st != nullptr)
+VideoState::AvSyncType VideoState::GetMasterSyncType() const {
+  if (sync_type_ == AV_SYNC_VIDEO_MASTER) {
+    if (p_image_stream_ != nullptr)
       return AV_SYNC_VIDEO_MASTER;
     else
       return AV_SYNC_AUDIO_MASTER;
-  } else if (av_sync_type == AV_SYNC_AUDIO_MASTER) {
-    if (audio_st != nullptr)
+  } else if (sync_type_ == AV_SYNC_AUDIO_MASTER) {
+    if (p_audio_stream_ != nullptr)
       return AV_SYNC_AUDIO_MASTER;
     else
       return AV_SYNC_EXTERNAL_CLOCK;
@@ -1183,14 +1259,14 @@ VideoState::AvSyncType VideoState::get_master_sync_type() const {
 }
 
 Clock *VideoState::get_master_clock() const {
-  AvSyncType master = get_master_sync_type();
+  AvSyncType master = GetMasterSyncType();
   if (master == AV_SYNC_VIDEO_MASTER) {
-    return pVidclk;
+    return p_image_clock_;
   }
   if (master == AV_SYNC_AUDIO_MASTER) {
-    return pAudclk;
+    return p_audio_clock_;
   }
-  return pExtclk;
+  return p_external_clock_;
 }
 
 /* prepare a new audio buffer */
@@ -1198,48 +1274,51 @@ void VideoState::audio_callback(uint8_t *stream, int len) {
   int audio_size, len1;
 
   while (len > 0) {
-    if (audio_buf_index >= audio_buf_size) {
-      audio_size = audio_decode_frame();
+    if (audio_buffer_index_ >= audio_buffer_size_) {
+      audio_size = DecodeAudioFrame();
       if (audio_size < 0) {
         /* if error, just output silence */
-        audio_buf = NULL;
-        audio_buf_size =
-            audio_buffer_size / audio_tgt.frame_size * audio_tgt.frame_size;
+        p_audio_buffer_ = NULL;
+        audio_buffer_size_ = audio_default_buffer_size_ /
+                             audio_params_target_.frame_size *
+                             audio_params_target_.frame_size;
       } else {
-        audio_buf_size = audio_size;
+        audio_buffer_size_ = audio_size;
       }
-      audio_buf_index = 0;
+      audio_buffer_index_ = 0;
     }
-    len1 = audio_buf_size - audio_buf_index;
+    len1 = audio_buffer_size_ - audio_buffer_index_;
     if (len1 > len)
       len1 = len;
-    if (!muted && audio_buf)
-      memcpy(stream, (uint8_t *)audio_buf + audio_buf_index, len1);
+    if (!is_muted_ && p_audio_buffer_)
+      memcpy(stream, (uint8_t *)p_audio_buffer_ + audio_buffer_index_, len1);
     else {
       memset(stream, 0, len1);
     }
     len -= len1;
     stream += len1;
-    audio_buf_index += len1;
+    audio_buffer_index_ += len1;
   }
-  audio_write_buf_size = audio_buf_size - audio_buf_index;
-  if (!isnan(audio_pts) && !muted) {
+  audio_write_buffer_size_ = audio_buffer_size_ - audio_buffer_index_;
+  if (!isnan(audio_pts_) && !is_muted_) {
     /* Let's assume the audio driver that is used by SDL has two periods. */
-    pAudclk->set_time(
-        audio_pts - (double)(2 * audio_hw_buf_size + audio_write_buf_size) /
-                        audio_tgt.bytes_per_sec,
-        audio_serial);
+    p_audio_clock_->set_time(
+        audio_pts_ -
+            (double)(2 * audio_hw_buffer_size_ + audio_write_buffer_size_) /
+                audio_params_target_.bytes_per_sec,
+        audio_serial_);
     // Sync external clock to audio clock
-    Clock::sync_slave_to_master(pExtclk, pAudclk, kAvNoSyncThreshold);
+    Clock::sync_slave_to_master(p_external_clock_, p_audio_clock_,
+                                kAvNoSyncThreshold);
   }
 }
 
-int VideoState::set_rate(double new_rate) {
+int VideoState::SetSpeed(double requested_speed) {
   // If we request a different rates
-  if (rate_value != new_rate) {
-    new_rate_value = new_rate;
-    new_rate_req = 1;
-    continue_read_thread.notify_one();
+  if (current_speed_ != requested_speed) {
+    requested_speed_ = requested_speed;
+    speed_request_ = true;
+    continue_read_thread_.notify_one();
   }
   return 0;
 }

--- a/src/main/cpp/VideoState.cpp
+++ b/src/main/cpp/VideoState.cpp
@@ -28,12 +28,12 @@ int VideoState::kVideoPictureQueueSize = 3; // int
 int VideoState::kSampleQueueSize = 9;       // int
 
 int VideoState::OpenStreamComponent(int stream_index) {
-  AVCodecContext *avctx;
-  AVCodec *codec;
-  const char *forced_codec_name = nullptr;
-  AVDictionary *opts = nullptr;
-  AVDictionaryEntry *t = nullptr;
-  int sample_rate, nb_channels;
+  AVCodecContext *p_codec_context;
+  AVCodec *p_codec;
+  AVDictionary *p_dict = nullptr;
+  AVDictionaryEntry *p_entry = nullptr;
+  int sample_rate;
+  int num_channels;
   int64_t channel_layout;
   int ret = 0;
 
@@ -43,20 +43,21 @@ int VideoState::OpenStreamComponent(int stream_index) {
     return -1;
   }
 
-  avctx = avcodec_alloc_context3(nullptr);
-  if (!avctx) {
+  p_codec_context = avcodec_alloc_context3(nullptr);
+  if (!p_codec_context) {
     return AVERROR(ENOMEM);
   }
 
   ret = avcodec_parameters_to_context(
-      avctx, p_format_context->streams[stream_index]->codecpar);
+      p_codec_context, p_format_context->streams[stream_index]->codecpar);
   if (ret < 0)
     goto fail;
-  avctx->pkt_timebase = p_format_context->streams[stream_index]->time_base;
+  p_codec_context->pkt_timebase =
+      p_format_context->streams[stream_index]->time_base;
 
-  codec = avcodec_find_decoder(avctx->codec_id);
+  p_codec = avcodec_find_decoder(p_codec_context->codec_id);
 
-  switch (avctx->codec_type) {
+  switch (p_codec_context->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
     last_audio_stream_ = stream_index;
     break;
@@ -65,31 +66,31 @@ int VideoState::OpenStreamComponent(int stream_index) {
     break;
   }
 
-  avctx->codec_id = codec->id;
+  p_codec_context->codec_id = p_codec->id;
 
   if (kEnableFastDecode) {
-    avctx->flags2 |= AV_CODEC_FLAG2_FAST;
+    p_codec_context->flags2 |= AV_CODEC_FLAG2_FAST;
   }
 
-  ret = GetFilterCodecOptions(opts, *codec_opts, avctx->codec_id,
+  ret = GetFilterCodecOptions(p_dict, *codec_opts, p_codec_context->codec_id,
                               p_format_context,
-                              p_format_context->streams[stream_index], codec);
+                              p_format_context->streams[stream_index], p_codec);
   if (ret) {
     goto fail;
   }
 
-  if (!av_dict_get(opts, "threads", NULL, 0)) {
-    av_dict_set(&opts, "threads", "auto", 0);
+  if (!av_dict_get(p_dict, "threads", NULL, 0)) {
+    av_dict_set(&p_dict, "threads", "auto", 0);
   }
-  if (avctx->codec_type == AVMEDIA_TYPE_VIDEO ||
-      avctx->codec_type == AVMEDIA_TYPE_AUDIO) {
-    av_dict_set(&opts, "refcounted_frames", "1", 0);
+  if (p_codec_context->codec_type == AVMEDIA_TYPE_VIDEO ||
+      p_codec_context->codec_type == AVMEDIA_TYPE_AUDIO) {
+    av_dict_set(&p_dict, "refcounted_frames", "1", 0);
   }
-  if ((ret = avcodec_open2(avctx, codec, &opts)) < 0) {
+  if ((ret = avcodec_open2(p_codec_context, p_codec, &p_dict)) < 0) {
     goto fail;
   }
-  if ((t = av_dict_get(opts, "", NULL, AV_DICT_IGNORE_SUFFIX))) {
-    av_log(NULL, AV_LOG_ERROR, "Option %s not found.\n", t->key);
+  if ((p_entry = av_dict_get(p_dict, "", NULL, AV_DICT_IGNORE_SUFFIX))) {
+    av_log(NULL, AV_LOG_ERROR, "Option %s not found.\n", p_entry->key);
     ret = AVERROR_OPTION_NOT_FOUND;
     goto fail;
   }
@@ -97,19 +98,19 @@ int VideoState::OpenStreamComponent(int stream_index) {
   end_of_file_ = false;
   p_format_context->streams[stream_index]->discard = AVDISCARD_DEFAULT;
 
-  switch (avctx->codec_type) {
+  switch (p_codec_context->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
 
-    sample_rate = avctx->sample_rate;
-    nb_channels = avctx->channels;
-    channel_layout = avctx->channel_layout;
+    sample_rate = p_codec_context->sample_rate;
+    num_channels = p_codec_context->channels;
+    channel_layout = p_codec_context->channel_layout;
 
     // prepare audio output
     if (!audio_open_callback) {
       goto fail;
     }
 
-    if ((ret = audio_open_callback(channel_layout, nb_channels, sample_rate,
+    if ((ret = audio_open_callback(channel_layout, num_channels, sample_rate,
                                    &audio_params_target_) < 0)) {
       goto fail;
     }
@@ -125,27 +126,28 @@ int VideoState::OpenStreamComponent(int stream_index) {
     // Since we do not have a precise enough audio FIFO fullness,
     // we correct audio sync only if larger than this threshold
     audio_diff_threshold_ =
-        (double)(audio_hw_buffer_size_) / audio_params_target_.bytes_per_sec;
+        (double)(audio_hw_buffer_size_) / audio_params_target_.bytes_per_sec_;
 
     audio_stream_index_ = stream_index;
     p_audio_stream_ = p_format_context->streams[stream_index];
-    p_audio_decoder_ =
-        new Decoder(avctx, p_audio_packet_queue_, &continue_read_thread_);
+    p_audio_decoder_ = new Decoder(p_codec_context, p_audio_packet_queue_,
+                                   &continue_read_thread_);
     if ((p_format_context->iformat->flags &
          (AVFMT_NOBINSEARCH | AVFMT_NOGENSEARCH | AVFMT_NO_BYTE_SEEK)) &&
         !p_format_context->iformat->read_seek) {
-      p_audio_decoder_->set_start_pts(p_audio_stream_->start_time);
-      p_audio_decoder_->set_start_pts_tb(p_audio_stream_->time_base);
+      p_audio_decoder_->SetStartPts(p_audio_stream_->start_time);
+      p_audio_decoder_->SetStartPtsTimebase(p_audio_stream_->time_base);
     }
-    if ((ret = p_audio_decoder_->start([this] { DecodeAudioPacketsToFrames(); })) < 0)
+    if ((ret = p_audio_decoder_->Start(
+             [this] { DecodeAudioPacketsToFrames(); })) < 0)
       goto out;
     if (pause_audio_device_callback)
       pause_audio_device_callback();
     break;
   case AVMEDIA_TYPE_VIDEO:
-    frame_width_ = avctx->width;
-    frame_height_ = avctx->height;
-    frame_aspect_ratio_ = avctx->sample_aspect_ratio;
+    frame_width_ = p_codec_context->width;
+    frame_height_ = p_codec_context->height;
+    frame_aspect_ratio_ = p_codec_context->sample_aspect_ratio;
 
     // TODO(fraudies): Alignment for the source does not seem to be necessary,
     // but test with more res avcodec_align_dimensions(avctx, &avctx->width,
@@ -165,9 +167,10 @@ int VideoState::OpenStreamComponent(int stream_index) {
       frame_rate_ = rational.num / rational.den;
     }
 
-    p_frame_decoder_ =
-        new Decoder(avctx, p_image_packet_queue_, &continue_read_thread_);
-    if ((ret = p_frame_decoder_->start([this] { DecodeImagePacketsToFrames(); })) < 0)
+    p_image_decoder_ = new Decoder(p_codec_context, p_image_packet_queue_,
+                                   &continue_read_thread_);
+    if ((ret = p_image_decoder_->Start(
+             [this] { DecodeImagePacketsToFrames(); })) < 0)
       goto out;
     queue_attachments_request_ = true;
     break;
@@ -177,20 +180,23 @@ int VideoState::OpenStreamComponent(int stream_index) {
   goto out;
 
 fail:
-  avcodec_free_context(&avctx);
+  avcodec_free_context(&p_codec_context);
 out:
-  av_dict_free(&opts);
+  av_dict_free(&p_dict);
 
   return ret;
 }
 
 int VideoState::GetImageFrame(AVFrame *frame) {
-  int got_picture;
+  int got_frame;
+  Clock *p_master_clock = nullptr;
+  GetMasterClock(&p_master_clock);
 
-  if ((got_picture = p_frame_decoder_->decode_frame(frame)) < 0)
+  if ((got_frame = p_image_decoder_->Decode(frame)) < 0) {
     return -1;
+  }
 
-  if (got_picture) {
+  if (got_frame) {
     double time = frame->pts != AV_NOPTS_VALUE
                       ? av_q2d(p_image_stream_->time_base) * frame->pts
                       : NAN;
@@ -200,61 +206,60 @@ int VideoState::GetImageFrame(AVFrame *frame) {
 
     if (GetMasterSyncType() != AV_SYNC_VIDEO_MASTER) {
       if (frame->pts != AV_NOPTS_VALUE) {
-        double diff = time - get_master_clock()->get_time();
+        double diff = time - p_master_clock->GetTime();
 
         av_log(NULL, AV_LOG_TRACE, "diff=%f time=%f np=%d\n", diff, time,
-               p_image_packet_queue_->get_nb_packets());
+               p_image_packet_queue_->getNumberOfPackets());
 
         if (!isnan(diff) && fabs(diff) < kAvNoSyncThreshold && diff < 0 &&
-            p_frame_decoder_->get_pkt_serial() ==
-                p_image_clock_->get_serial() &&
-            p_image_packet_queue_->get_nb_packets()) {
+            p_image_decoder_->GetSerial() == p_image_clock_->GetSerial() &&
+            p_image_packet_queue_->getNumberOfPackets()) {
           num_frame_drops_early_++;
           av_frame_unref(frame);
-          got_picture = 0;
+          got_frame = 0;
         }
       }
     }
   }
 
-  return got_picture;
+  return got_frame;
 }
 
-int VideoState::QueueImage(AVFrame *image_frame, double pts, double duration,
+int VideoState::QueueImage(AVFrame *p_image_frame, double pts, double duration,
                            int64_t pos, int serial) {
-  Frame *frame = nullptr;
-
-  if (!(frame = p_image_frame_queue_->peek_writable())) {
+  Frame *p_frame = nullptr;
+  p_image_frame_queue_->PeekWritable(&p_frame);
+  if (!p_frame) {
     return -1;
   }
 
-  frame->aspect_ration = image_frame->sample_aspect_ratio;
-  frame->uploaded = 0;
+  p_frame->aspect_ratio_ = p_image_frame->sample_aspect_ratio;
+  p_frame->is_uploaded_ = false;
 
-  frame->width = image_frame->width;
-  frame->height = image_frame->height;
-  frame->format = image_frame->format;
+  p_frame->width_ = p_image_frame->width;
+  p_frame->height_ = p_image_frame->height;
+  p_frame->format_ = p_image_frame->format;
 
-  frame->pts = pts;
-  frame->duration = duration;
-  frame->pos = pos;
-  frame->serial = serial;
+  p_frame->pts_ = pts;
+  p_frame->duration_ = duration;
+  p_frame->byte_pos_ = pos;
+  p_frame->serial_ = serial;
 
-  av_frame_move_ref(frame->frame, image_frame);
-  p_image_frame_queue_->push();
+  av_frame_move_ref(p_frame->p_frame_, p_image_frame);
+  p_image_frame_queue_->Push();
   return 0;
 }
 
 void VideoState::CloseStreamComponent(int stream_index) {
-  AVCodecParameters *codecpar;
+  AVCodecParameters *p_codec_parameters;
 
   if (stream_index < 0 || stream_index >= p_format_context->nb_streams)
     return;
-  codecpar = p_format_context->streams[stream_index]->codecpar;
+  p_codec_parameters = p_format_context->streams[stream_index]->codecpar;
 
-  switch (codecpar->codec_type) {
+  switch (p_codec_parameters->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
-    p_audio_decoder_->abort(p_audio_frame_queue_);
+    p_audio_decoder_->Stop(p_audio_frame_queue_);
     delete p_audio_decoder_;
     swr_free(&swr_ctx);
     av_freep(&p_audio_buffer1_);
@@ -262,15 +267,15 @@ void VideoState::CloseStreamComponent(int stream_index) {
     p_audio_buffer_ = nullptr;
     break;
   case AVMEDIA_TYPE_VIDEO:
-    p_frame_decoder_->abort(p_image_frame_queue_);
-    delete p_frame_decoder_;
+    p_image_decoder_->Stop(p_image_frame_queue_);
+    delete p_image_decoder_;
     break;
   default:
     break;
   }
 
   p_format_context->streams[stream_index]->discard = AVDISCARD_ALL;
-  switch (codecpar->codec_type) {
+  switch (p_codec_parameters->codec_type) {
   case AVMEDIA_TYPE_AUDIO:
     p_audio_stream_ = nullptr;
     audio_stream_index_ = -1;
@@ -286,11 +291,11 @@ void VideoState::CloseStreamComponent(int stream_index) {
 
 bool VideoState::StreamHasEnoughPackets(const AVStream &stream, int stream_id,
                                         const PacketQueue &packet_queue) {
-  return stream_id < 0 || packet_queue.is_abort_request() ||
+  return stream_id < 0 || packet_queue.IsAbortRequested() ||
          (stream.disposition & AV_DISPOSITION_ATTACHED_PIC) ||
-         packet_queue.get_nb_packets() > kMinFrames &&
-             (!packet_queue.get_duration() ||
-              av_q2d(stream.time_base) * packet_queue.get_duration() > 1.0);
+         packet_queue.getNumberOfPackets() > kMinFrames &&
+             (!packet_queue.GetDuration() ||
+              av_q2d(stream.time_base) * packet_queue.GetDuration() > 1.0);
 }
 
 int VideoState::CheckStreamSpecifier(AVFormatContext *p_format_context,
@@ -373,7 +378,7 @@ int VideoState::GetFilterCodecOptions(AVDictionary *p_opts_out,
 
 int VideoState::SetupStreamOptions(AVDictionary ***opts,
                                    AVFormatContext *p_frame_context,
-                                   AVDictionary *codec_opts) {
+                                   AVDictionary *p_codec_opts) {
   int err = 0;
 
   if (!p_frame_context->nb_streams) {
@@ -387,7 +392,7 @@ int VideoState::SetupStreamOptions(AVDictionary ***opts,
   }
   for (int i = 0; i < p_frame_context->nb_streams; i++) {
     // TODO: Handle error here
-    err = GetFilterCodecOptions((*opts)[i], *codec_opts,
+    err = GetFilterCodecOptions((*opts)[i], *p_codec_opts,
                                 p_frame_context->streams[i]->codecpar->codec_id,
                                 p_frame_context, p_frame_context->streams[i],
                                 NULL);
@@ -405,8 +410,10 @@ int VideoState::SynchronizeAudio(int nb_samples) {
   if (GetMasterSyncType() != AV_SYNC_AUDIO_MASTER) {
     double diff, avg_diff;
     int min_nb_samples, max_nb_samples;
+    Clock *p_master_clock = nullptr;
+    GetMasterClock(&p_master_clock);
 
-    diff = p_audio_clock_->get_time() - get_master_clock()->get_time();
+    diff = p_audio_clock_->GetTime() - p_master_clock->GetTime();
 
     if (!isnan(diff) && fabs(diff) < kAvNoSyncThreshold) {
       audio_diff_cum_ = diff + audio_diff_avg_coef_ * audio_diff_cum_;
@@ -419,7 +426,7 @@ int VideoState::SynchronizeAudio(int nb_samples) {
 
         if (fabs(avg_diff) >= audio_diff_threshold_) {
           wanted_nb_samples =
-              nb_samples + (int)(diff * audio_parms_source_.freq);
+              nb_samples + (int)(diff * audio_parms_source_.frequency_);
           min_nb_samples =
               ((nb_samples * (100 - kSampleCorrectionMaxPercent) / 100));
           max_nb_samples =
@@ -442,87 +449,97 @@ int VideoState::SynchronizeAudio(int nb_samples) {
 }
 
 int VideoState::DecodeAudioFrame() {
-  int data_size, resampled_data_size;
+  int data_size;
+  int resampled_data_size;
   int64_t dec_channel_layout;
   int wanted_nb_samples;
-  Frame *af;
+  Frame *p_audio_frame = nullptr;
   double original_sample_rate;
 
   if (is_paused_)
     return -1;
 
   do {
-    if (!(af = p_audio_frame_queue_->peek_readable()))
+    p_audio_frame_queue_->PeekReadable(&p_audio_frame);
+    if (!p_audio_frame) {
       return -1;
-    p_audio_frame_queue_->next();
-  } while (af->serial != p_audio_packet_queue_->get_serial());
+    }
+    p_audio_frame_queue_->Next();
+  } while (p_audio_frame->serial_ != p_audio_packet_queue_->GetSerial());
 
   data_size = av_samples_get_buffer_size(
-      NULL, af->frame->channels, af->frame->nb_samples,
-      static_cast<AVSampleFormat>(af->frame->format), 1);
+      NULL, p_audio_frame->p_frame_->channels,
+      p_audio_frame->p_frame_->nb_samples,
+      static_cast<AVSampleFormat>(p_audio_frame->p_frame_->format), 1);
 
   dec_channel_layout =
-      (af->frame->channel_layout &&
-       af->frame->channels ==
-           av_get_channel_layout_nb_channels(af->frame->channel_layout))
-          ? af->frame->channel_layout
-          : av_get_default_channel_layout(af->frame->channels);
-  wanted_nb_samples = SynchronizeAudio(af->frame->nb_samples);
+      (p_audio_frame->p_frame_->channel_layout &&
+       p_audio_frame->p_frame_->channels ==
+           av_get_channel_layout_nb_channels(
+               p_audio_frame->p_frame_->channel_layout))
+          ? p_audio_frame->p_frame_->channel_layout
+          : av_get_default_channel_layout(p_audio_frame->p_frame_->channels);
+  wanted_nb_samples = SynchronizeAudio(p_audio_frame->p_frame_->nb_samples);
 
-  original_sample_rate = af->frame->sample_rate;
+  original_sample_rate = p_audio_frame->p_frame_->sample_rate;
   // Change the sample_rate by the playback rate
-  af->frame->sample_rate *= current_speed_;
+  p_audio_frame->p_frame_->sample_rate *= current_speed_;
 
-  if (af->frame->format != audio_parms_source_.fmt ||
-      dec_channel_layout != audio_parms_source_.channel_layout ||
-      af->frame->sample_rate != audio_parms_source_.freq ||
-      (wanted_nb_samples != af->frame->nb_samples && !swr_ctx)) {
+  if (p_audio_frame->p_frame_->format != audio_parms_source_.sample_format_ ||
+      dec_channel_layout != audio_parms_source_.channel_layout_ ||
+      p_audio_frame->p_frame_->sample_rate != audio_parms_source_.frequency_ ||
+      (wanted_nb_samples != p_audio_frame->p_frame_->nb_samples && !swr_ctx)) {
     swr_free(&swr_ctx);
-    swr_ctx = swr_alloc_set_opts(NULL, audio_params_target_.channel_layout,
-                                 audio_params_target_.fmt,
-                                 audio_params_target_.freq, dec_channel_layout,
-                                 static_cast<AVSampleFormat>(af->frame->format),
-                                 af->frame->sample_rate, 0, NULL);
+    swr_ctx = swr_alloc_set_opts(
+        NULL, audio_params_target_.channel_layout_,
+        audio_params_target_.sample_format_, audio_params_target_.frequency_,
+        dec_channel_layout,
+        static_cast<AVSampleFormat>(p_audio_frame->p_frame_->format),
+        p_audio_frame->p_frame_->sample_rate, 0, NULL);
     if (!swr_ctx || swr_init(swr_ctx) < 0) {
       av_log(NULL, AV_LOG_ERROR,
              "Cannot create sample rate converter for conversion of %d Hz %s "
              "%d channels to %d Hz %s %d channels!\n",
-             af->frame->sample_rate,
+             p_audio_frame->p_frame_->sample_rate,
              av_get_sample_fmt_name(
-                 static_cast<AVSampleFormat>(af->frame->format)),
-             af->frame->channels, audio_params_target_.freq,
-             av_get_sample_fmt_name(audio_params_target_.fmt),
-             audio_params_target_.channels);
+                 static_cast<AVSampleFormat>(p_audio_frame->p_frame_->format)),
+             p_audio_frame->p_frame_->channels, audio_params_target_.frequency_,
+             av_get_sample_fmt_name(audio_params_target_.sample_format_),
+             audio_params_target_.num_channels_);
       swr_free(&swr_ctx);
       return -1;
     }
-    audio_parms_source_.channel_layout = dec_channel_layout;
-    audio_parms_source_.channels = af->frame->channels;
-    audio_parms_source_.freq = af->frame->sample_rate;
-    audio_parms_source_.fmt = static_cast<AVSampleFormat>(af->frame->format);
+    audio_parms_source_.channel_layout_ = dec_channel_layout;
+    audio_parms_source_.num_channels_ = p_audio_frame->p_frame_->channels;
+    audio_parms_source_.frequency_ = p_audio_frame->p_frame_->sample_rate;
+    audio_parms_source_.sample_format_ =
+        static_cast<AVSampleFormat>(p_audio_frame->p_frame_->format);
   }
 
   if (swr_ctx) {
-    const uint8_t **in = (const uint8_t **)af->frame->extended_data;
+    const uint8_t **in =
+        (const uint8_t **)p_audio_frame->p_frame_->extended_data;
     uint8_t **out = &p_audio_buffer1_;
-    int out_count = (int64_t)wanted_nb_samples * audio_params_target_.freq /
-                        af->frame->sample_rate +
+    int out_count = (int64_t)wanted_nb_samples *
+                        audio_params_target_.frequency_ /
+                        p_audio_frame->p_frame_->sample_rate +
                     256;
-    int out_size =
-        av_samples_get_buffer_size(NULL, audio_params_target_.channels,
-                                   out_count, audio_params_target_.fmt, 0);
+    int out_size = av_samples_get_buffer_size(
+        NULL, audio_params_target_.num_channels_, out_count,
+        audio_params_target_.sample_format_, 0);
     int len2;
     if (out_size < 0) {
       av_log(NULL, AV_LOG_ERROR, "av_samples_get_buffer_size() failed\n");
       return -1;
     }
-    if (wanted_nb_samples != af->frame->nb_samples) {
-      if (swr_set_compensation(swr_ctx,
-                               (wanted_nb_samples - af->frame->nb_samples) *
-                                   audio_params_target_.freq /
-                                   af->frame->sample_rate,
-                               wanted_nb_samples * audio_params_target_.freq /
-                                   af->frame->sample_rate) < 0) {
+    if (wanted_nb_samples != p_audio_frame->p_frame_->nb_samples) {
+      if (swr_set_compensation(
+              swr_ctx,
+              (wanted_nb_samples - p_audio_frame->p_frame_->nb_samples) *
+                  audio_params_target_.frequency_ /
+                  p_audio_frame->p_frame_->sample_rate,
+              wanted_nb_samples * audio_params_target_.frequency_ /
+                  p_audio_frame->p_frame_->sample_rate) < 0) {
         av_log(NULL, AV_LOG_ERROR, "swr_set_compensation() failed\n");
         return -1;
       }
@@ -530,7 +547,8 @@ int VideoState::DecodeAudioFrame() {
     av_fast_malloc(&p_audio_buffer1_, &audio_buffer1_size_, out_size);
     if (!p_audio_buffer1_)
       return AVERROR(ENOMEM);
-    len2 = swr_convert(swr_ctx, out, out_count, in, af->frame->nb_samples);
+    len2 = swr_convert(swr_ctx, out, out_count, in,
+                       p_audio_frame->p_frame_->nb_samples);
     if (len2 < 0) {
       av_log(NULL, AV_LOG_ERROR, "swr_convert() failed\n");
       return -1;
@@ -541,18 +559,21 @@ int VideoState::DecodeAudioFrame() {
         swr_free(&swr_ctx);
     }
     p_audio_buffer_ = p_audio_buffer1_;
-    resampled_data_size = len2 * audio_params_target_.channels *
-                          av_get_bytes_per_sample(audio_params_target_.fmt);
+    resampled_data_size =
+        len2 * audio_params_target_.num_channels_ *
+        av_get_bytes_per_sample(audio_params_target_.sample_format_);
   } else {
-    p_audio_buffer_ = af->frame->data[0];
+    p_audio_buffer_ = p_audio_frame->p_frame_->data[0];
     resampled_data_size = data_size;
   }
 
   /* update the audio clock with the pts */
-  audio_pts_ = isnan(af->pts) ? NAN
-                              : af->pts + (double)af->frame->nb_samples /
-                                              original_sample_rate;
-  audio_serial_ = af->serial;
+  audio_pts_ =
+      isnan(p_audio_frame->pts_)
+          ? NAN
+          : p_audio_frame->pts_ + (double)p_audio_frame->p_frame_->nb_samples /
+                                      original_sample_rate;
+  audio_serial_ = p_audio_frame->serial_;
 
   return resampled_data_size;
 }
@@ -566,7 +587,7 @@ VideoState::VideoState(int audio_buffer_size)
       queue_attachments_request_(false), seek_request_(false),
       seek_flags_(AVSEEK_FLAG_BACKWARD), // AV_SEEK_BACKWARD
       seek_time_(0), seek_distance_(0), sync_type_(AV_SYNC_AUDIO_MASTER),
-      frame_rate_(0), video_clock_last_set_time_(0), image_stream_index_(0),
+      frame_rate_(0), image_clock_last_set_time_(0), image_stream_index_(0),
       max_frame_duration_(0), end_of_file_(false), duration_(0),
       frame_width_(0), frame_height_(0), frame_aspect_ratio_(av_make_q(0, 0)),
       is_stepping_(false), speed_request_(false), requested_speed_(1.0),
@@ -576,7 +597,7 @@ VideoState::VideoState(int audio_buffer_size)
       p_audio_frame_queue_(nullptr), p_image_frame_queue_(nullptr),
       p_audio_clock_(nullptr), p_image_clock_(nullptr),
       p_external_clock_(nullptr), p_audio_decoder_(nullptr),
-      p_frame_decoder_(nullptr), p_reader_thread_(nullptr),
+      p_image_decoder_(nullptr), p_reader_thread_(nullptr),
       p_input_format_(nullptr), p_format_context(nullptr), swr_ctx(nullptr),
       p_audio_stream_(nullptr), p_image_stream_(nullptr),
       audio_stream_index_(0), audio_pts_(0.0), audio_serial_(0),
@@ -615,31 +636,35 @@ int VideoState::CreateVideoState(VideoState **pp_video_state,
   }
 
   // Handle frame queues
-  (*pp_video_state)->p_audio_frame_queue_ = FrameQueue::create_frame_queue(
-      (*pp_video_state)->p_audio_packet_queue_, kSampleQueueSize, 1);
-  if (!(*pp_video_state)->p_audio_frame_queue_) {
+  if (FrameQueue::CreateFrameQueue(&(*pp_video_state)->p_audio_frame_queue_,
+                                   (*pp_video_state)->p_audio_packet_queue_,
+                                   kSampleQueueSize, true)) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for audio");
     delete *pp_video_state;
     return ENOMEM;
   }
-  (*pp_video_state)->p_image_frame_queue_ = FrameQueue::create_frame_queue(
-      (*pp_video_state)->p_image_packet_queue_, kVideoPictureQueueSize, 1);
-  if (!(*pp_video_state)->p_image_frame_queue_) {
+
+  if (FrameQueue::CreateFrameQueue(&(*pp_video_state)->p_image_frame_queue_,
+                                   (*pp_video_state)->p_image_packet_queue_,
+                                   kVideoPictureQueueSize, true)) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create frame queue for video");
     delete *pp_video_state;
     return ENOMEM;
   }
 
   // Create clocks
-  (*pp_video_state)->p_audio_clock_ = new (std::nothrow)
-      Clock((*pp_video_state)->p_audio_packet_queue_->get_p_serial());
+  int *p_audio_serial = nullptr;
+  (*pp_video_state)->p_audio_packet_queue_->GetPtrSerial(&p_audio_serial);
+  (*pp_video_state)->p_audio_clock_ = new (std::nothrow) Clock(p_audio_serial);
   if (!(*pp_video_state)->p_audio_clock_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create clock for audio");
     delete *pp_video_state;
     return ENOMEM;
   }
-  (*pp_video_state)->p_image_clock_ = new (std::nothrow)
-      Clock((*pp_video_state)->p_image_packet_queue_->get_p_serial());
+
+  int *p_image_serial = nullptr;
+  (*pp_video_state)->p_image_packet_queue_->GetPtrSerial(&p_image_serial);
+  (*pp_video_state)->p_image_clock_ = new (std::nothrow) Clock(p_image_serial);
   if (!(*pp_video_state)->p_image_clock_) {
     av_log(NULL, AV_LOG_ERROR, "Unable to create clock for video");
     delete *pp_video_state;
@@ -680,21 +705,21 @@ VideoState::~VideoState() {
 
   // From close method
   if (p_image_packet_queue_)
-    delete (p_image_packet_queue_);
+    delete p_image_packet_queue_;
   if (p_audio_packet_queue_)
-    delete (p_audio_packet_queue_);
+    delete p_audio_packet_queue_;
 
   if (p_image_frame_queue_)
-    delete (p_image_frame_queue_);
+    delete p_image_frame_queue_;
   if (p_audio_frame_queue_)
-    delete (p_audio_frame_queue_);
+    delete p_audio_frame_queue_;
 
   if (p_image_clock_)
-    delete (p_image_clock_);
+    delete p_image_clock_;
   if (p_audio_clock_)
-    delete (p_audio_clock_);
+    delete p_audio_clock_;
   if (p_external_clock_)
-    delete (p_external_clock_);
+    delete p_external_clock_;
 }
 
 //* Gets the stream from the disk or the network */
@@ -781,18 +806,18 @@ int VideoState::ReadPacketsToQueues() {
                p_format_context->url);
       } else {
         if (audio_stream_index_ >= 0) {
-          p_audio_packet_queue_->flush();
-          p_audio_packet_queue_->put_flush_packet();
+          p_audio_packet_queue_->Flush();
+          p_audio_packet_queue_->PutFlushPacket();
         }
         if (image_stream_index_ >= 0) {
-          p_image_packet_queue_->flush();
-          p_image_packet_queue_->put_flush_packet();
+          p_image_packet_queue_->Flush();
+          p_image_packet_queue_->PutFlushPacket();
         }
         if (seek_flags_ & AVSEEK_FLAG_BYTE) {
-          p_external_clock_->set_time(
+          p_external_clock_->SetTime(
               NAN, 0); // 0 != -1 which will return NAN for interim time
         } else {
-          p_external_clock_->set_time(
+          p_external_clock_->SetTime(
               seek_target / (double)AV_TIME_BASE,
               0); // 0 != -1 which will return NAN for interim time
         }
@@ -800,12 +825,19 @@ int VideoState::ReadPacketsToQueues() {
       seek_request_ = false;
       queue_attachments_request_ = true;
       end_of_file_ = false;
+      Clock *p_external_clock = nullptr;
+      Clock *p_image_clock = nullptr;
+      Clock *p_audio_clock = nullptr;
+      GetExternalClock(&p_external_clock);
+      GetImageClock(&p_image_clock);
+      GetAudioClock(&p_audio_clock);
+
       av_log(NULL, AV_LOG_INFO,
              "Seek: ext: %7.2f sec - aud : %7.2f sec - vid : %7.2f sec - Error "
              ": %7.2f sec\n",
-             get_pExtclk()->get_time(), get_pAudclk()->get_time(),
-             get_pVidclk()->get_time(),
-             fabs(get_pExtclk()->get_time() - get_pAudclk()->get_time()));
+             p_external_clock->GetTime(), p_audio_clock->GetTime(),
+             p_image_clock->GetTime(),
+             fabs(p_external_clock->GetTime() - p_audio_clock->GetTime()));
 
       if (is_paused_) {
         step_to_next_frame_callback(); // Assume that the step callback is set
@@ -823,14 +855,14 @@ int VideoState::ReadPacketsToQueues() {
         AVPacket copy = {0};
         if ((ret = av_packet_ref(&copy, &p_image_stream_->attached_pic)) < 0)
           goto fail;
-        p_image_packet_queue_->put(&copy);
-        p_image_packet_queue_->put_null_packet(image_stream_index_);
+        p_image_packet_queue_->Put(&copy);
+        p_image_packet_queue_->PutNullPacket(image_stream_index_);
       }
       queue_attachments_request_ = false;
     }
 
     /* if the queues are full, no need to read more */
-    if (p_audio_packet_queue_->get_size() + p_image_packet_queue_->get_size() >
+    if (p_audio_packet_queue_->GetSize() + p_image_packet_queue_->GetSize() >
             kMaxQueueSize ||
         (StreamHasEnoughPackets(*p_audio_stream_, audio_stream_index_,
                                 *p_audio_packet_queue_) &&
@@ -843,14 +875,14 @@ int VideoState::ReadPacketsToQueues() {
       continue;
     }
     if (!is_paused_ &&
-        (!p_audio_stream_ || (p_audio_decoder_->is_finished() ==
-                                  p_audio_packet_queue_->get_serial() &&
-                              p_audio_frame_queue_->nb_remaining() == 0)) &&
-        (!p_image_stream_ || (p_frame_decoder_->is_finished() ==
-                                  p_image_packet_queue_->get_serial() &&
-                              p_image_frame_queue_->nb_remaining() == 0))) {
+        (!p_audio_stream_ || (p_audio_decoder_->IsFinished() ==
+                                  p_audio_packet_queue_->GetSerial() &&
+                              p_audio_frame_queue_->GetNumToDisplay() == 0)) &&
+        (!p_image_stream_ || (p_image_decoder_->IsFinished() ==
+                                  p_image_packet_queue_->GetSerial() &&
+                              p_image_frame_queue_->GetNumToDisplay() == 0))) {
       if (num_loop_ != 1 && (!num_loop_ || --num_loop_)) {
-        stream_seek(start_time_ != AV_NOPTS_VALUE ? start_time_ : 0, 0, 0);
+        Seek(start_time_ != AV_NOPTS_VALUE ? start_time_ : 0, 0, 0);
       }
     }
     ret = av_read_frame(p_format_context, pkt);
@@ -858,10 +890,10 @@ int VideoState::ReadPacketsToQueues() {
       if ((ret == AVERROR_EOF || avio_feof(p_format_context->pb)) &&
           !end_of_file_) {
         if (image_stream_index_ >= 0) {
-          p_image_packet_queue_->put_null_packet(image_stream_index_);
+          p_image_packet_queue_->PutNullPacket(image_stream_index_);
         }
         if (audio_stream_index_ >= 0) {
-          p_audio_packet_queue_->put_null_packet(audio_stream_index_);
+          p_audio_packet_queue_->PutNullPacket(audio_stream_index_);
         }
         end_of_file_ = true;
 
@@ -899,10 +931,10 @@ int VideoState::ReadPacketsToQueues() {
             ((double)max_duration_ / 1000000);
 
     if (pkt->stream_index == audio_stream_index_ && pkt_in_play_range) {
-      p_audio_packet_queue_->put(pkt);
+      p_audio_packet_queue_->Put(pkt);
     } else if (pkt->stream_index == image_stream_index_ && pkt_in_play_range &&
                !(p_image_stream_->disposition & AV_DISPOSITION_ATTACHED_PIC)) {
-      p_image_packet_queue_->put(pkt);
+      p_image_packet_queue_->Put(pkt);
     } else {
       av_packet_unref(pkt);
     }
@@ -922,80 +954,86 @@ fail:
 
 /* Called when the stream is opened */
 int VideoState::DecodeAudioPacketsToFrames() {
-  AVFrame *frame = av_frame_alloc();
-  Frame *af;
+  AVFrame *p_frame = av_frame_alloc();
+  Frame *p_audio_frame = nullptr;
 
   int got_frame = 0;
   AVRational tb;
   int ret = 0;
 
-  if (!frame)
+  if (!p_frame) {
     return AVERROR(ENOMEM);
+  }
 
   do {
-    if ((got_frame = p_audio_decoder_->decode_frame(frame)) < 0)
+    if ((got_frame = p_audio_decoder_->Decode(p_frame)) < 0) {
       goto the_end;
+    }
 
     if (got_frame) {
-      tb = av_make_q(1, frame->sample_rate);
-
-      if (!(af = p_audio_frame_queue_->peek_writable()))
+      tb = av_make_q(1, p_frame->sample_rate);
+      p_audio_frame_queue_->PeekWritable(&p_audio_frame);
+      if (!p_audio_frame) {
         goto the_end;
+      }
 
       av_log(NULL, AV_LOG_TRACE, "Audio frame pts = %I64d, tb = %2.7f\n",
-             frame->pts, av_q2d(tb));
+             p_frame->pts, av_q2d(tb));
 
-      af->pts = (frame->pts == AV_NOPTS_VALUE) ? NAN : frame->pts * av_q2d(tb);
-      af->pos = frame->pkt_pos;
-      af->serial = p_audio_decoder_->get_pkt_serial();
-      af->duration = av_q2d(av_make_q(frame->nb_samples, frame->sample_rate));
+      p_audio_frame->pts_ =
+          (p_frame->pts == AV_NOPTS_VALUE) ? NAN : p_frame->pts * av_q2d(tb);
+      p_audio_frame->byte_pos_ = p_frame->pkt_pos;
+      p_audio_frame->serial_ = p_audio_decoder_->GetSerial();
+      p_audio_frame->duration_ =
+          av_q2d(av_make_q(p_frame->nb_samples, p_frame->sample_rate));
 
-      av_frame_move_ref(af->frame, frame);
-      p_audio_frame_queue_->push();
+      av_frame_move_ref(p_audio_frame->p_frame_, p_frame);
+      p_audio_frame_queue_->Push();
     }
   } while (ret >= 0 || ret == AVERROR(EAGAIN) || ret == AVERROR_EOF);
 the_end:
-  av_frame_free(&frame);
+  av_frame_free(&p_frame);
   return ret;
 }
 
 /* Called when the stream is opened */
 int VideoState::DecodeImagePacketsToFrames() {
-  AVFrame *frame = av_frame_alloc();
+  AVFrame *p_frame = av_frame_alloc();
   double pts;
   double duration;
   int ret;
-  AVRational tb = p_image_stream_->time_base;
+  AVRational time_base = p_image_stream_->time_base;
   AVRational frame_rate =
       av_guess_frame_rate(p_format_context, p_image_stream_, NULL);
 
-  if (!frame) {
+  if (!p_frame) {
     return AVERROR(ENOMEM);
   }
 
   for (;;) {
-    ret = GetImageFrame(frame);
+    ret = GetImageFrame(p_frame);
     if (ret < 0)
       goto the_end;
     if (!ret)
       continue;
 
     av_log(NULL, AV_LOG_TRACE, " Video frame pts = %I64d, tb = %2.7f\n",
-           frame->pts, av_q2d(tb));
+           p_frame->pts, av_q2d(time_base));
 
     duration = (frame_rate.num && frame_rate.den)
                    ? av_q2d(av_make_q(frame_rate.den, frame_rate.num))
                    : 0;
-    pts = (frame->pts == AV_NOPTS_VALUE) ? NAN : frame->pts * av_q2d(tb);
-    ret = QueueImage(frame, pts, duration, frame->pkt_pos,
-                     p_frame_decoder_->get_pkt_serial());
-    av_frame_unref(frame);
+    pts = (p_frame->pts == AV_NOPTS_VALUE) ? NAN
+                                           : p_frame->pts * av_q2d(time_base);
+    ret = QueueImage(p_frame, pts, duration, p_frame->pkt_pos,
+                     p_image_decoder_->GetSerial());
+    av_frame_unref(p_frame);
 
     if (ret < 0)
       goto the_end;
   }
 the_end:
-  av_frame_free(&frame);
+  av_frame_free(&p_frame);
   return 0;
 }
 
@@ -1024,11 +1062,11 @@ int VideoState::OpenStream(VideoState **pp_video_state, const char *filename,
 int VideoState::StartStream() {
   int i, ret;
   int st_index[AVMEDIA_TYPE_NB];
-  AVDictionaryEntry *t;
+  AVDictionaryEntry *p_entry = nullptr;
   int scan_all_pmts_set = 0;
-  AVDictionary *format_opts = nullptr;
+  AVDictionary *p_format_opts = nullptr;
   AVDictionary *codec_opts = nullptr;
-  AVDictionary **opts = nullptr;
+  AVDictionary **pp_opts_dict = nullptr;
 
   memset(st_index, -1, sizeof(st_index));
   last_video_stream_ = image_stream_index_ = -1;
@@ -1041,22 +1079,22 @@ int VideoState::StartStream() {
     ret = AVERROR(ENOMEM);
     goto fail;
   }
-  p_format_context->interrupt_callback.callback = decode_interrupt_cb_bridge;
+  p_format_context->interrupt_callback.callback = DecodeInterruptBridge;
   p_format_context->interrupt_callback.opaque = this;
-  if (!av_dict_get(format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE)) {
-    av_dict_set(&format_opts, "scan_all_pmts", "1", AV_DICT_DONT_OVERWRITE);
+  if (!av_dict_get(p_format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE)) {
+    av_dict_set(&p_format_opts, "scan_all_pmts", "1", AV_DICT_DONT_OVERWRITE);
     scan_all_pmts_set = 1;
   }
   ret = avformat_open_input(&p_format_context, filename_, p_input_format_,
-                            &format_opts);
+                            &p_format_opts);
   if (ret < 0) {
     goto fail;
   }
   if (scan_all_pmts_set)
-    av_dict_set(&format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE);
+    av_dict_set(&p_format_opts, "scan_all_pmts", NULL, AV_DICT_MATCH_CASE);
 
-  if ((t = av_dict_get(format_opts, "", NULL, AV_DICT_IGNORE_SUFFIX))) {
-    av_log(NULL, AV_LOG_ERROR, "Option %s not found.\n", t->key);
+  if ((p_entry = av_dict_get(p_format_opts, "", NULL, AV_DICT_IGNORE_SUFFIX))) {
+    av_log(NULL, AV_LOG_ERROR, "Option %s not found.\n", p_entry->key);
     ret = AVERROR_OPTION_NOT_FOUND;
     goto fail;
   }
@@ -1068,17 +1106,17 @@ int VideoState::StartStream() {
   av_format_inject_global_side_data(p_format_context);
 
   // Find the stream information
-  ret = SetupStreamOptions(&opts, p_format_context, codec_opts);
+  ret = SetupStreamOptions(&pp_opts_dict, p_format_context, codec_opts);
   if (ret) {
     // TODO(fraudies): Clean up dictionary memory
     goto fail;
   }
 
-  ret = avformat_find_stream_info(p_format_context, opts);
+  ret = avformat_find_stream_info(p_format_context, pp_opts_dict);
   for (i = 0; i < p_format_context->nb_streams; i++) {
-    av_dict_free(&opts[i]);
+    av_dict_free(&pp_opts_dict[i]);
   }
-  av_freep(&opts);
+  av_freep(&pp_opts_dict);
 
   if (ret < 0) {
     av_log(NULL, AV_LOG_WARNING, "%s: could not find codec parameters\n",
@@ -1157,7 +1195,8 @@ int VideoState::StartStream() {
     player_state_callbacks[TO_READY]();
   }
 
-  p_reader_thread_ = new (std::nothrow) std::thread([this] { ReadPacketsToQueues(); });
+  p_reader_thread_ =
+      new (std::nothrow) std::thread([this] { ReadPacketsToQueues(); });
   if (!p_reader_thread_) {
     av_log(NULL, AV_LOG_FATAL, "Unable to create reader thread\n");
     ret = AVERROR(ENOMEM);
@@ -1177,18 +1216,21 @@ fail:
   return ret;
 }
 
-void VideoState::update_pts(double pts, int serial) {
-  get_pVidclk()->set_time(pts, serial);
-  video_clock_last_set_time_ = av_gettime_relative() / 1000000.0;
+void VideoState::SetPts(double pts, int serial) {
+  p_external_clock_->SetTime(pts, serial);
+
+  // GetImageClock()->set_time(pts, serial);
+  image_clock_last_set_time_ = av_gettime_relative() / 1000000.0;
   // Sync external clock to video clock
-  Clock::sync_slave_to_master(get_pExtclk(), get_pVidclk(), kAvNoSyncThreshold);
+  Clock::SyncSlaveToMaster(p_external_clock_, p_image_clock_,
+                           kAvNoSyncThreshold);
 }
 
 /* seek in the stream */
-void VideoState::stream_seek(int64_t pos, int64_t rel, int seek_by_bytes) {
+void VideoState::Seek(int64_t time, int64_t distance, bool seek_by_bytes) {
   if (!seek_request_) {
-    seek_time_ = pos;
-    seek_distance_ = rel;
+    seek_time_ = time;
+    seek_distance_ = distance;
     seek_flags_ &= ~AVSEEK_FLAG_BYTE;
     if (seek_by_bytes) {
       seek_flags_ |= AVSEEK_FLAG_BYTE;
@@ -1212,14 +1254,16 @@ int isBigEndian() {
   return (u.c[sizeof(long int) - 1] == 1);
 }
 
-double VideoState::compute_target_delay(double delay) {
+double VideoState::ComputeTargetDelay(double delay) {
   double sync_threshold, diff = 0;
+  Clock *p_master_clock = nullptr;
+  GetMasterClock(&p_master_clock);
 
   /* update delay to follow master synchronisation source */
   if (GetMasterSyncType() != AV_SYNC_VIDEO_MASTER) {
     /* if video is slave, we try to correct big delays by
     duplicating or deleting a frame */
-    diff = p_image_clock_->get_time() - get_master_clock()->get_time();
+    diff = p_image_clock_->GetTime() - p_master_clock->GetTime();
 
     /* skip or repeat frame. We take into account the
     delay to compute the threshold. I still don't know
@@ -1258,19 +1302,19 @@ VideoState::AvSyncType VideoState::GetMasterSyncType() const {
   }
 }
 
-Clock *VideoState::get_master_clock() const {
+void VideoState::GetMasterClock(Clock **pp_clock) const {
   AvSyncType master = GetMasterSyncType();
   if (master == AV_SYNC_VIDEO_MASTER) {
-    return p_image_clock_;
+    *pp_clock = p_image_clock_;
   }
   if (master == AV_SYNC_AUDIO_MASTER) {
-    return p_audio_clock_;
+    *pp_clock = p_audio_clock_;
   }
-  return p_external_clock_;
+  *pp_clock = p_external_clock_;
 }
 
 /* prepare a new audio buffer */
-void VideoState::audio_callback(uint8_t *stream, int len) {
+void VideoState::GetAudioCallback(uint8_t *stream, int len) {
   int audio_size, len1;
 
   while (len > 0) {
@@ -1280,8 +1324,8 @@ void VideoState::audio_callback(uint8_t *stream, int len) {
         /* if error, just output silence */
         p_audio_buffer_ = NULL;
         audio_buffer_size_ = audio_default_buffer_size_ /
-                             audio_params_target_.frame_size *
-                             audio_params_target_.frame_size;
+                             audio_params_target_.frame_size_ *
+                             audio_params_target_.frame_size_;
       } else {
         audio_buffer_size_ = audio_size;
       }
@@ -1302,14 +1346,14 @@ void VideoState::audio_callback(uint8_t *stream, int len) {
   audio_write_buffer_size_ = audio_buffer_size_ - audio_buffer_index_;
   if (!isnan(audio_pts_) && !is_muted_) {
     /* Let's assume the audio driver that is used by SDL has two periods. */
-    p_audio_clock_->set_time(
+    p_audio_clock_->SetTime(
         audio_pts_ -
             (double)(2 * audio_hw_buffer_size_ + audio_write_buffer_size_) /
-                audio_params_target_.bytes_per_sec,
+                audio_params_target_.bytes_per_sec_,
         audio_serial_);
     // Sync external clock to audio clock
-    Clock::sync_slave_to_master(p_external_clock_, p_audio_clock_,
-                                kAvNoSyncThreshold);
+    Clock::SyncSlaveToMaster(p_external_clock_, p_audio_clock_,
+                             kAvNoSyncThreshold);
   }
 }
 

--- a/src/main/cpp/VideoState.h
+++ b/src/main/cpp/VideoState.h
@@ -14,27 +14,32 @@
 #include "PacketQueue.h"
 
 extern "C" {
-#include "libavutil/avstring.h"
-#include "libavutil/eval.h"
-#include "libavutil/mathematics.h"
-#include "libavutil/pixdesc.h"
-#include "libavutil/imgutils.h"
-#include "libavutil/dict.h"
-#include "libavutil/parseutils.h"
-#include "libavutil/samplefmt.h"
-#include "libavutil/avassert.h"
-#include "libavutil/time.h"
-#include "libavutil/log.h"
-#include "libavformat/avformat.h"
-#include "libavdevice/avdevice.h"
-#include "libswscale/swscale.h"
-#include "libavutil/opt.h"
 #include "libavcodec/avfft.h"
+#include "libavdevice/avdevice.h"
+#include "libavformat/avformat.h"
+#include "libavutil/avassert.h"
+#include "libavutil/avstring.h"
+#include "libavutil/dict.h"
+#include "libavutil/eval.h"
+#include "libavutil/imgutils.h"
+#include "libavutil/log.h"
+#include "libavutil/mathematics.h"
+#include "libavutil/opt.h"
+#include "libavutil/parseutils.h"
+#include "libavutil/pixdesc.h"
+#include "libavutil/samplefmt.h"
+#include "libavutil/time.h"
 #include "libswresample/swresample.h"
+#include "libswscale/swscale.h"
 #include <assert.h>
 }
 
-// what will be the streamer in the future implementations
+// Video state holds the state of the video player for both
+// the image stream and audio stream
+// It also provides an interface to change that state, e.g.
+// playing, stopping, pausing the playback
+//
+// TODO(fraudies): Encapsulate audio and image stream decoding
 class VideoState {
 public:
   enum AvSyncType {
@@ -54,90 +59,94 @@ public:
   };
 
 private:
-  int abort_request;
-  bool paused; // TODO(fraudies): Check if this need to be atomic
-  int last_paused;
-  bool stopped; // TODO(fraudies): Check if this need to be atomic
-  int queue_attachments_req;
-  int seek_req;
-  int seek_flags;
-  int64_t seek_pos;
-  int64_t seek_rel;
-  int read_pause_return;
-  int av_sync_type;
-  int fps;
+  bool abort_request_;
+  bool is_paused_; // TODO(fraudies): Check if this need to be atomic
+  bool last_is_paused_;
+  bool is_stopped_; // TODO(fraudies): Check if this need to be atomic
+  bool queue_attachments_request_;
 
-  double vidclk_last_set_time;
-  int video_stream;
-  double max_frame_duration; // maximum duration of a frame - above this, we
-                             // consider the jump a timestamp discontinuity
-  int eof;
-  int image_width;
-  int image_height;
-  double video_duration;
-  AVRational image_sample_aspect_ratio;
-  bool step; // TODO(fraudies): Check if this need to be atomic
+  bool seek_request_;
+  int seek_flags_;
+  int64_t seek_time_;
+  int64_t seek_distance_; // Signed distance between the current time and the
+                          // seek time
+  AvSyncType sync_type_;  // default is AV_SYNC_AUDIO_MASTER
+  int frame_rate_;        // Frame rate in Hz (frames per second)
 
-  double new_rate_value;
-  double rate_value;
-  int new_rate_req;
+  double video_clock_last_set_time_;
+  int image_stream_index_;
+  double max_frame_duration_; // maximum duration of a frame - above this, we
+                              // consider the jump a timestamp discontinuity
+  bool end_of_file_;
+  int frame_width_;
+  int frame_height_;
+  double duration_;
+  AVRational frame_aspect_ratio_;
+  bool is_stepping_; // TODO(fraudies): Check if this need to be atomic
 
-  int audio_disable;
-  int video_disable;
+  // Playback speed variables
+  double requested_speed_;
+  double current_speed_;
+  bool speed_request_;
 
-  int last_video_stream;
-  int last_audio_stream;
+  bool audio_disabled_;
+  bool video_disabled_;
 
-  std::condition_variable continue_read_thread;
+  int last_video_stream_;
+  int last_audio_stream_;
 
-  char *filename;
+  std::condition_variable continue_read_thread_;
 
-  PacketQueue *pAudioq;
-  PacketQueue *pVideoq;
+  char *filename_;
 
-  FrameQueue *pSampq;
-  FrameQueue *pPictq;
+  PacketQueue *p_audio_packet_queue_;
+  PacketQueue *p_image_packet_queue_;
 
-  Clock *pAudclk;
-  Clock *pVidclk;
-  Clock *pExtclk;
+  FrameQueue *p_audio_frame_queue_;
+  FrameQueue *p_image_frame_queue_;
 
-  Decoder *pAuddec;
-  Decoder *pViddec;
+  Clock *p_audio_clock_;
+  Clock *p_image_clock_;
+  Clock *p_external_clock_;
 
-  std::thread *read_tid;
-  AVInputFormat *iformat;
-  AVFormatContext *ic;
+  Decoder *p_audio_decoder_;
+  Decoder *p_frame_decoder_;
+
+  std::thread *p_reader_thread_;
+  AVInputFormat *p_input_format_;
+  AVFormatContext *p_format_context;
   struct SwrContext *swr_ctx;
 
-  AVStream *audio_st;
-  AVStream *video_st;
+  AVStream *p_audio_stream_;
+  AVStream *p_image_stream_;
 
-  int audio_stream;
-  double audio_pts;
-  int audio_serial;
-  double audio_diff_cum; /* used for AV difference average computation */
-  double audio_diff_avg_coef;
-  double audio_diff_threshold;
-  int audio_diff_avg_count;
-  int audio_hw_buf_size;
-  int audio_buffer_size;
-  uint8_t *audio_buf;
-  uint8_t *audio_buf1;
-  unsigned int audio_buf_size; /* in bytes */
-  unsigned int audio_buf1_size;
-  int audio_buf_index; /* in bytes */
-  int audio_write_buf_size;
-  int muted;
-  struct AudioParams audio_src;
-  struct AudioParams audio_tgt;
-  int frame_drops_early;
-  int64_t start_time;   // initial start time
-  int64_t max_duration; // initial play time
-  int loop;             // loop through the video
+  int audio_stream_index_;
+  double audio_pts_;
+  int audio_serial_;
+  double audio_diff_cum_; /* used for AV difference average computation */
+  double audio_diff_avg_coef_;
+  double audio_diff_threshold_;
+  int audio_diff_avg_count_;
+  int audio_hw_buffer_size_;
+  int audio_default_buffer_size_;
+  uint8_t *p_audio_buffer_;
+  uint8_t *p_audio_buffer1_;
+  unsigned int audio_buffer_size_; // in bytes
+  unsigned int audio_buffer1_size_;
+  int audio_buffer_index_; // in bytes
+  int audio_write_buffer_size_;
+  bool is_muted_;
+  struct AudioParams audio_parms_source_;
+  struct AudioParams audio_params_target_;
+  int num_frame_drops_early_;
+  int64_t start_time_;   // initial start time
+  int64_t max_duration_; // initial play time
+  int num_loop_;         // loop through the video
 
-  inline int cmp_audio_fmts(enum AVSampleFormat fmt1, int64_t channel_count1,
-                            enum AVSampleFormat fmt2, int64_t channel_count2) {
+  inline int CompareAudioFormats(enum AVSampleFormat fmt1,
+                                 int64_t channel_count1,
+                                 enum AVSampleFormat fmt2,
+                                 int64_t channel_count2) {
     /* If channel count == 1, planar and non-planar formats are the same */
     return (channel_count1 == 1 && channel_count2 == 1)
                ? av_get_packed_sample_fmt(fmt1) !=
@@ -145,8 +154,7 @@ private:
                : channel_count1 != channel_count2 || fmt1 != fmt2;
   }
 
-  inline int64_t get_valid_channel_layout(int64_t channel_layout,
-                                          int channels) {
+  inline int64_t GetValidChannelLayout(int64_t channel_layout, int channels) {
     return (channel_layout &&
             av_get_channel_layout_nb_channels(channel_layout) == channels)
                ? channel_layout
@@ -154,40 +162,38 @@ private:
   }
 
   /* open a given stream. Return 0 if OK */
-  int stream_component_open(int stream_index);
-  int get_video_frame(AVFrame *frame);
+  int OpenStreamComponent(int stream_index);
+  int GetImageFrame(AVFrame *frame);
 
-  int queue_picture(AVFrame *src_frame, double pts, double duration,
-                    int64_t pos, int serial);
-  void stream_component_close(int stream_index);
-  int stream_has_enough_packets(AVStream *st, int stream_id,
-                                PacketQueue *queue);
+  int QueueImage(AVFrame *image_frame, double pts, double duration, int64_t pos,
+                 int serial);
+  void CloseStreamComponent(int stream_index);
+  bool StreamHasEnoughPackets(const AVStream &p_stream, int stream_index,
+                              const PacketQueue &packet_queue);
 
-  /* Ported this function from cmdutils */
-  int check_stream_specifier(AVFormatContext *s, AVStream *st,
-                             const char *spec);
+  // pointers are left because the low level c routines require a pointer
+  // that they can modify
+  int CheckStreamSpecifier(AVFormatContext *p_format_contex, AVStream *p_stream,
+                           const char *specifier);
 
-  /*ported this function from cmdutils*/
-  AVDictionary *filter_codec_opts(AVDictionary *opts, enum AVCodecID codec_id,
-                                  AVFormatContext *s, AVStream *st,
-                                  AVCodec *codec);
+  int GetFilterCodecOptions(AVDictionary *p_opts_out,
+                            const AVDictionary &opts_in, AVCodecID codec_id,
+                            AVFormatContext *p_format_context,
+                            AVStream *p_stream, AVCodec *p_codec);
 
-  /* From cmd utils*/
-  AVDictionary **setup_find_stream_info_opts(AVFormatContext *s,
-                                             AVDictionary *codec_opts);
+  int SetupStreamOptions(AVDictionary ***opts, AVFormatContext *s,
+                         AVDictionary *codec_opts);
 
-  /* return the wanted number of samples to get better sync if sync_type is
-   * video or external master clock */
-  int synchronize_audio(int nb_samples);
+  // return the wanted number of samples to get better sync if sync_type is
+  // video or external master clock
+  int SynchronizeAudio(int nb_samples);
 
-  /**
-   * Decode one audio frame and return its uncompressed size.
-   *
-   * The processed audio frame is decoded, converted if required, and
-   * stored in is->audio_buf, with size in bytes given by the return
-   * value.
-   */
-  int audio_decode_frame();
+  // Decode one audio frame and return its uncompressed size.
+  //
+  // The processed audio frame is decoded, converted if required, and
+  // stored in is->audio_buf, with size in bytes given by the return
+  // value.
+  int DecodeAudioFrame();
 
   std::function<void()>
       player_state_callbacks[VideoState::NUM_PLAYER_STATE_CALLBACKS];
@@ -199,8 +205,8 @@ private:
   std::function<void()> step_to_next_frame_callback;
   VideoState(int audio_buffer_size);
 
-  /* get the current synchronization type */
-  AvSyncType get_master_sync_type() const;
+  // get the current synchronization type
+  AvSyncType GetMasterSyncType() const;
 
   static bool kEnableShowFormat;
   static bool kEnableFastDecode;
@@ -215,127 +221,124 @@ private:
   static int kVideoPictureQueueSize;
   static int kSampleQueueSize;
 
+  static int CreateVideoState(VideoState **pp_video_state,
+                              int audio_buffer_size);
+
 public:
   static double kAvSyncThresholdMax;
   static int kEnableSeekByBytes;
-  static VideoState *create_video_state(int audio_buffer_size);
+  virtual ~VideoState();
 
-  ~VideoState();
-
-  int read_thread();
-  int audio_thread();
-  int video_thread();
-  int stream_start();
-  static VideoState *stream_open(const char *filename, AVInputFormat *iformat,
-                                 int audio_buffer_size);
+  int ReadPacketsToQueues();
+  int DecodeAudioPacketsToFrames();
+  int DecodeImagePacketsToFrames();
+  int StartStream();
+  static int OpenStream(VideoState **pp_video_state, const char *filename,
+                        AVInputFormat *iformat, int audio_buffer_size);
 
   inline void
-  set_player_state_callback_func(PlayerStateCallback callback,
+  SetPlayerStateCallbackFunction(PlayerStateCallback callback,
                                  const std::function<void()> &func) {
     player_state_callbacks[callback] = func;
   }
 
-  inline void set_audio_open_callback(
+  inline void SetAudioOpenCallback(
       const std::function<int(int64_t, int, int, struct AudioParams *)> &func) {
     audio_open_callback = func;
   }
 
-  inline void
-  set_pause_audio_device_callback(const std::function<void()> &func) {
+  inline void SetPauseAudioDeviceCallback(const std::function<void()> &func) {
     pause_audio_device_callback = func;
   }
 
-  inline void set_destroy_callback(const std::function<void()> &func) {
+  inline void SetDestroyCallback(const std::function<void()> &func) {
     destroy_callback = func;
   }
 
-  inline void
-  set_step_to_next_frame_callback(const std::function<void()> &func) {
+  inline void SetStepToNextFrameCallback(const std::function<void()> &func) {
     step_to_next_frame_callback = func;
   }
 
   /* Controls */
-  inline int get_image_width() const { return image_width; }
-  inline int get_image_height() const { return image_height; }
-  inline AVRational get_image_sample_aspect_ratio() const {
-    return image_sample_aspect_ratio;
-  }
-  inline bool has_audio_data() const { return last_audio_stream >= 0; }
-  inline bool has_image_data() const { return last_video_stream >= 0; }
-  inline double get_duration() const {
-    return video_duration;
-  }; // duration in sec
+  inline int GetFrameWidth() const { return frame_width_; }
+  inline int GetFrameHeight() const { return frame_height_; }
+  inline AVRational GetFrameAspectRatio() const { return frame_aspect_ratio_; }
+  inline bool has_audio_data() const { return last_audio_stream_ >= 0; }
+  inline bool has_image_data() const { return last_video_stream_ >= 0; }
+  inline double get_duration() const { return duration_; }; // duration in sec
   inline double get_stream_time() const {
-    return pVidclk->get_time();
+    return p_image_clock_->get_time();
   } // current time in sec
-  inline void toggle_mute() { muted = !muted; }
+  inline void toggle_mute() { is_muted_ = !is_muted_; }
   void update_pts(double pts, int serial);
   void stream_seek(int64_t pos, int64_t rel, int seek_by_bytes);
 
   /* Setter and Getters */
-  inline bool get_paused() const { return paused; }
-  inline void set_paused(bool new_paused) { paused = new_paused; }
+  inline bool get_paused() const { return is_paused_; }
+  inline void set_paused(bool new_paused) { is_paused_ = new_paused; }
 
-  inline bool get_stopped() const { return stopped; }
-  inline void set_stopped(bool new_stopped) { stopped = new_stopped; }
+  inline bool get_stopped() const { return is_stopped_; }
+  inline void set_stopped(bool new_stopped) { is_stopped_ = new_stopped; }
 
-  inline int get_step() const { return step; }
-  inline void set_step(bool new_step) { step = new_step; }
+  inline int IsStepping() const { return is_stepping_; }
+  inline void SetStepping(bool stepping) { is_stepping_ = stepping; }
 
-  int set_rate(double new_rate);
-  inline double get_rate() const { return rate_value; }
+  int SetSpeed(double requested_speed);
+  inline double GetSpeed() const { return current_speed_; }
 
-  inline int get_frame_drops_early() const { return frame_drops_early; }
+  inline int get_frame_drops_early() const { return num_frame_drops_early_; }
 
-  inline const char *get_filename() const { return filename; }
+  inline const char *get_filename() const { return filename_; }
 
-  inline AVStream *get_audio_st() const { return audio_st; }
-  inline AVStream *get_video_st() const { return video_st; }
+  inline AVStream *get_audio_st() const { return p_audio_stream_; }
+  inline AVStream *get_video_st() const { return p_image_stream_; }
 
-  inline FrameQueue *get_pPictq() const { return pPictq; }
-  inline FrameQueue *get_pSampq() const { return pSampq; }
+  inline FrameQueue *get_pPictq() const { return p_image_frame_queue_; }
+  inline FrameQueue *get_pSampq() const { return p_audio_frame_queue_; }
 
-  inline PacketQueue *get_pVideoq() const { return pVideoq; }
-  inline PacketQueue *get_pAudioq() const { return pAudioq; }
+  inline PacketQueue *get_pVideoq() const { return p_image_packet_queue_; }
+  inline PacketQueue *get_pAudioq() const { return p_audio_packet_queue_; }
 
-  inline Clock *get_pVidclk() const { return pVidclk; }
-  inline Clock *get_pAudclk() const { return pAudclk; }
-  inline Clock *get_pExtclk() const { return pExtclk; }
+  inline Clock *get_pVidclk() const { return p_image_clock_; }
+  inline Clock *get_pAudclk() const { return p_audio_clock_; }
+  inline Clock *get_pExtclk() const { return p_external_clock_; }
 
   inline double get_vidclk_last_set_time() const {
-    return vidclk_last_set_time;
+    return video_clock_last_set_time_;
   }
 
-  inline AudioParams get_audio_tgt() const { return audio_tgt; }
-  inline int get_muted() const { return muted; }
+  inline AudioParams get_audio_tgt() const { return audio_params_target_; }
+  inline int get_muted() const { return is_muted_; }
 
-  inline Decoder *get_pViddec() const { return pViddec; }
-  inline AVFormatContext *get_ic() const { return ic; }
+  inline Decoder *get_pViddec() const { return p_frame_decoder_; }
+  inline AVFormatContext *get_ic() const { return p_format_context; }
 
-  inline int64_t get_seek_pos() const { return seek_pos; }
+  inline int64_t get_seek_pos() const { return seek_time_; }
 
-  inline int get_video_stream() const { return video_stream; }
-  inline int get_audio_stream() const { return audio_stream; }
+  inline int get_video_stream() const { return image_stream_index_; }
+  inline int get_audio_stream() const { return audio_stream_index_; }
 
-  inline double get_max_frame_duration() const { return max_frame_duration; }
+  inline double get_max_frame_duration() const { return max_frame_duration_; }
 
-  inline int decode_interrupt_cb() const { return abort_request; }
+  inline int decode_interrupt_cb() const { return abort_request_; }
 
   double compute_target_delay(double delay);
 
   /* get the current master clock */
   Clock *get_master_clock() const;
 
-  inline double get_fps() const { return video_st ? this->fps : 0; }
+  inline double GetFrameRate() const {
+    return p_image_stream_ ? this->frame_rate_ : 0;
+  }
 
   /* prepare a new audio buffer */
   void audio_callback(uint8_t *stream, int len);
 
-  inline int get_audio_disable() const { return audio_disable; }
-  inline void set_audio_disable(const int disable) { audio_disable = disable; }
+  inline bool GetAudioDisabled() const { return audio_disabled_; }
+  inline void SetAudioDisabled(bool disabled) { audio_disabled_ = disabled; }
 
-  inline int get_video_disable() const { return video_disable; }
-  inline void set_video_disable(const int disable) { video_disable = disable; }
+  inline bool GetVideoDisabled() const { return video_disabled_; }
+  inline void SetVideoDisabled(bool disabled) { video_disabled_ = disabled; }
 };
 
 // Note, this bridge is necessary to interface with ffmpeg's call decode

--- a/src/main/cpp/VideoState.vcxitems
+++ b/src/main/cpp/VideoState.vcxitems
@@ -45,7 +45,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)PacketQueue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Pipeline.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PipelineOptions.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)Singleton.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)VideoState.h" />
   </ItemGroup>
 </Project>

--- a/src/main/cpp/player.cpp
+++ b/src/main/cpp/player.cpp
@@ -5,13 +5,13 @@ int runFFmpegPlayer(const char *input_filename, AVInputFormat *file_iformat) {
 
   av_log_set_flags(AV_LOG_SKIP_REPEATED);
   av_log(NULL, AV_LOG_WARNING, "Init Network\n");
-  FfmpegSdlAvPlayback *pPlayer = new FfmpegSdlAvPlayback();
-  int err = pPlayer->Init(input_filename, file_iformat);
+  FfmpegSdlAvPlayback *p_player = new FfmpegSdlAvPlayback();
+  int err = p_player->OpenVideo(input_filename, file_iformat);
   if (err) {
     fprintf(stderr, "Error %d when opening input file %s", err, input_filename);
     return err;
   }
-  pPlayer->init_and_event_loop();
+  FfmpegSdlAvPlayback::InitializeAndListenForEvents(p_player);
 }
 
 int runMpvPlayer(const char *input_filename) {

--- a/src/main/cpp/player.cpp
+++ b/src/main/cpp/player.cpp
@@ -16,7 +16,7 @@ int runFFmpegPlayer(const char *input_filename, AVInputFormat *file_iformat) {
 
 int runMpvPlayer(const char *input_filename) {
   MpvAvPlayback *pPlayer = new MpvAvPlayback();
-  pPlayer->init_and_event_loop(input_filename);
+  pPlayer->InitAndEventLoop(input_filename);
   return 0;
 }
 


### PR DESCRIPTION
- Naming of variables and methods
- Visibility and scope of variables and methods
- Documentation
- Move public methods to the top