### PR TITLE
Update PTS When Init image display thread 

### DIFF
--- a/src/main/cpp/FfmpegJavaAvPlayback.cpp
+++ b/src/main/cpp/FfmpegJavaAvPlayback.cpp
@@ -211,6 +211,7 @@ bool FfmpegJavaAvPlayback::DoDisplay(double *remaining_time) {
         av_diff = p_master_clock->GetTime() - p_image_clock->GetTime();
       else if (p_video_state_->HasAudioStream())
         av_diff = p_master_clock->GetTime() - p_audio_clock->GetTime();
+#ifdef DEBUG
       av_log(
           NULL, AV_LOG_INFO,
           "m %7.2f, a %7.2f, v %7.2f at %1.3fX %s:%7.3f de=%4d dl=%4d "
@@ -234,6 +235,7 @@ bool FfmpegJavaAvPlayback::DoDisplay(double *remaining_time) {
               ? p_decoder->GetNumberOfIncorrectPtsValues()
               : 0);
       fflush(stdout);
+#endif
       last_time = cur_time;
     }
   }

--- a/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegJavaMediaPlayer.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegJavaMediaPlayer.java
@@ -124,6 +124,10 @@ public final class FfmpegJavaMediaPlayer extends FfmpegMediaPlayer implements Me
     if (hasImageData()) {
       initAndStartImagePlayer();
     }
+
+    synchronized (initLock) {
+      initLock.notify();
+    }
   }
 
   @Override

--- a/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegMediaPlayer.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegMediaPlayer.java
@@ -54,7 +54,6 @@ abstract class FfmpegMediaPlayer extends DatavyuMediaPlayer {
           e.printStackTrace();
         }
       }
-      System.out.println("PTS " + getPresentationTime());
     }
 
     @Override

--- a/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegMediaPlayer.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/FfmpegMediaPlayer.java
@@ -14,6 +14,8 @@ abstract class FfmpegMediaPlayer extends DatavyuMediaPlayer {
 
   private PlayerStateListener stateListener;
 
+  protected final Object initLock = new Object();
+
   /**
    * Create an ffmpeg media player instance
    *
@@ -42,7 +44,18 @@ abstract class FfmpegMediaPlayer extends DatavyuMediaPlayer {
   class FfmpegPlayerStateListener implements PlayerStateListener {
 
     @Override
-    public void onReady(PlayerStateEvent evt) {}
+    public void onReady(PlayerStateEvent evt) {
+      synchronized (initLock) {
+        try {
+          // wait for the initialization of the Java Side
+          // This will make sure to have a correct PTS
+          initLock.wait(100);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+      System.out.println("PTS " + getPresentationTime());
+    }
 
     @Override
     public void onPlaying(PlayerStateEvent evt) {

--- a/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
+++ b/src/main/java/org/datavyu/plugins/ffmpeg/ImageCanvasPlayerThread.java
@@ -114,9 +114,11 @@ class ImageCanvasPlayerThread extends Thread {
     this.imgHeight = height;
     // Allocate byte buffer
     this.data = new byte[this.imgWidth * this.imgHeight * NUM_COLOR_CHANNELS];
+    // Update the Image buffer to Pull a frame from the queue and update
+    // the PTS from NaN to 0.0 sec
+    mediaPlayerData.updateImageData(data);
     // Set defaults
-    cm =
-        new ComponentColorModel(
+    cm = new ComponentColorModel(
             colorSpace, false, false, Transparency.OPAQUE, DataBuffer.TYPE_BYTE);
     sm = cm.createCompatibleSampleModel(this.imgWidth, this.imgHeight);
     // Initialize an empty image


### PR DESCRIPTION
The Video State (VideoState.cpp) will force a refresh at start-up without updating the pts, which put the Clock PTS to NaN, The media player engine will not perform a seek when PTS is NaN.

By forcing the Java Side to update the native image buffer and the PTS and initialization, we will ensure that the PTS will match the displayed frame. 

Adding a lock to wait for the complete initialization of the Java Side, will make sure that both the state of the Native Side is Ready and all threads in the Java Side are running.

closes #134 